### PR TITLE
Various accounting session improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In the example above:
 - The usage is sent to the accounting service when exiting the context manager, unless an exception is raised, because in this case we suppose that the actual business logic to be charged didn't get executed.
 - The value of `estimated_count` is used for reservation, and it's used also for usage unless a new value is assigned to `acc_session.count`.
 
-Longrun session can be used without context manager:
+Accounting session can be also used without the context manager:
 
 ```python
 subtype: ServiceSubtype = ...
@@ -70,7 +70,7 @@ acc_session = accounting_session_factory.longrun_session(
 )
 
 await acc_session.make_reservation()
-await acc_session.start()
+await acc_session.start() # start method is required only for longrun sessions.
 
 # Actual logic
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,35 @@ In the example above:
 - The usage is sent to the accounting service when exiting the context manager, unless an exception is raised, because in this case we suppose that the actual business logic to be charged didn't get executed.
 - The value of `estimated_count` is used for reservation, and it's used also for usage unless a new value is assigned to `acc_session.count`.
 
+Longrun session can be used without context manager:
+
+```python
+subtype: ServiceSubtype = ...
+proj_id: UUID = ...
+user_id: UUID = ...
+name: str | None = ...
+estimated_instances: int = ...
+instance_type: str = ...
+instances: int = ...
+duration: int = ...
+acc_session = accounting_session_factory.longrun_session(
+    subtype=subtype,
+    proj_id=proj_id,
+    user_id=user_id,
+    name=name,
+    instance_type="FARGATE",
+    instances=1,
+    duration=5,
+)
+
+await acc_session.make_reservation()
+await acc_session.start()
+
+# Actual logic
+
+await acc_session.finish()
+```
+
 > [!TIP]
 > The integration with the Accounting service can be disabled by setting the env variable `ACCOUNTING_DISABLED=1` before initializing the `AsyncAccountingSessionFactory` or `AccountingSessionFactory` object.
 

--- a/demo/app/api.py
+++ b/demo/app/api.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import AsyncIterator
-from contextlib import aclosing, asynccontextmanager
+from contextlib import aclosing, asynccontextmanager, closing
 from typing import Annotated, Any
 from uuid import UUID
 
@@ -11,7 +11,7 @@ from starlette import status
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from obp_accounting_sdk import AsyncAccountingSessionFactory
+from obp_accounting_sdk import AccountingSessionFactory, AsyncAccountingSessionFactory
 from obp_accounting_sdk.constants import ServiceSubtype
 from obp_accounting_sdk.errors import (
     AccountingReservationError,
@@ -19,9 +19,9 @@ from obp_accounting_sdk.errors import (
     InsufficientFundsError,
 )
 
-from .dependencies import AccountingSessionFactoryDep
-from .schema import QueryRequest, QueryResponse
-from .service import run_query
+from .dependencies import AsyncAccountingSessionFactoryDep, SyncAccountingSessionFactoryDep
+from .schema import JobRequest, JobResponse, QueryRequest, QueryResponse
+from .service import run_async_job, run_query, run_sync_job
 
 L = logging.getLogger(__name__)
 
@@ -30,8 +30,12 @@ L = logging.getLogger(__name__)
 async def lifespan(_: FastAPI) -> AsyncIterator[dict[str, Any]]:
     """Execute actions on server startup and shutdown."""
     L.info("Starting api")
-    async with aclosing(AsyncAccountingSessionFactory()) as session_factory:
-        yield {"session_factory": session_factory}
+    async with aclosing(AsyncAccountingSessionFactory()) as async_session_factory:
+        with closing(AccountingSessionFactory()) as sync_session_factory:
+            yield {
+                "async_session_factory": async_session_factory,
+                "sync_session_factory": sync_session_factory,
+            }
 
 
 app = FastAPI(title="Demo", lifespan=lifespan)
@@ -67,7 +71,7 @@ async def accounting_error_handler(
 @app.post("/query")
 async def query(
     query_request: QueryRequest,
-    accounting_session_factory: AccountingSessionFactoryDep,
+    accounting_session_factory: AsyncAccountingSessionFactoryDep,
     project_id: Annotated[UUID | None, Header()],
     user_id: Annotated[UUID | None, Header()],
 ) -> QueryResponse:
@@ -84,5 +88,70 @@ async def query(
         acc_session.count = actual_count
     return QueryResponse(
         input_text=query_request.input_text,
+        output_text=output_text,
+    )
+
+
+@app.post("/async-job")
+async def async_job(
+    job_request: JobRequest,
+    accounting_session_factory: AsyncAccountingSessionFactoryDep,
+    project_id: Annotated[UUID | None, Header()],
+    user_id: Annotated[UUID | None, Header()],
+) -> JobResponse:
+    """Execute a long running job."""
+    acc_session = accounting_session_factory.longrun_session(
+        subtype=ServiceSubtype.SMALL_CIRCUIT_SIM,
+        proj_id=project_id,
+        user_id=user_id,
+        instances=1,
+        instance_type="FARGATE",
+        duration=5,
+    )
+    L.info("Created longrun session: %s", acc_session)
+
+    await acc_session.make_reservation()
+    L.info("Made reservation for longrun session: %s", acc_session)
+
+    await acc_session.start()
+    L.info("Started longrun session: %s", acc_session)
+
+    output_text = await run_async_job(job_request.input_text)
+    L.info("Finished job")
+
+    await acc_session.finish()
+    L.info("Finished longrun session: %s", acc_session)
+
+    return JobResponse(
+        input_text=job_request.input_text,
+        output_text=output_text,
+    )
+
+
+@app.post("/job")
+def job(
+    job_request: JobRequest,
+    accounting_session_factory: SyncAccountingSessionFactoryDep,
+    project_id: Annotated[UUID | None, Header()],
+    user_id: Annotated[UUID | None, Header()],
+) -> JobResponse:
+    """Execute a long running job."""
+    acc_session = accounting_session_factory.longrun_session(
+        subtype=ServiceSubtype.SMALL_CIRCUIT_SIM,
+        proj_id=project_id,
+        user_id=user_id,
+        instances=1,
+        instance_type="FARGATE",
+        duration=5,
+    )
+
+    acc_session.make_reservation()
+
+    acc_session.start()
+    output_text = run_sync_job(job_request.input_text)
+    acc_session.finish()
+
+    return JobResponse(
+        input_text=job_request.input_text,
         output_text=output_text,
     )

--- a/demo/app/dependencies.py
+++ b/demo/app/dependencies.py
@@ -5,13 +5,21 @@ from typing import Annotated
 from fastapi import Depends
 from starlette.requests import Request
 
-from obp_accounting_sdk import AsyncAccountingSessionFactory
+from obp_accounting_sdk import AccountingSessionFactory, AsyncAccountingSessionFactory
 
 
-def _get_accounting_session_factory(request: Request) -> AsyncAccountingSessionFactory:
-    return request.state.session_factory
+def _get_accounting_async_session_factory(request: Request) -> AsyncAccountingSessionFactory:
+    return request.state.async_session_factory
 
 
-AccountingSessionFactoryDep = Annotated[
-    AsyncAccountingSessionFactory, Depends(_get_accounting_session_factory)
+def _get_accounting_sync_session_factory(request: Request) -> AccountingSessionFactory:
+    return request.state.sync_session_factory
+
+
+AsyncAccountingSessionFactoryDep = Annotated[
+    AsyncAccountingSessionFactory, Depends(_get_accounting_async_session_factory)
+]
+
+SyncAccountingSessionFactoryDep = Annotated[
+    AccountingSessionFactory, Depends(_get_accounting_sync_session_factory)
 ]

--- a/demo/app/schema.py
+++ b/demo/app/schema.py
@@ -14,3 +14,16 @@ class QueryResponse(BaseModel):
 
     input_text: str
     output_text: str
+
+
+class JobRequest(BaseModel):
+    """JobRequest."""
+
+    input_text: str
+
+
+class JobResponse(BaseModel):
+    """JobResponse."""
+
+    input_text: str
+    output_text: str

--- a/demo/app/service.py
+++ b/demo/app/service.py
@@ -1,6 +1,21 @@
 """Service."""
 
+import asyncio
+import time
+
 
 async def run_query(input_text: str) -> str:
     """Run a query."""
     return f"some output based on {input_text!r}"
+
+
+async def run_async_job(input_text: str) -> str:
+    """Run a long running job."""
+    await asyncio.sleep(60)
+    return f"some output based on {input_text!r}$"
+
+
+def run_sync_job(input_text: str) -> str:
+    """Run a long running job."""
+    time.sleep(60)
+    return f"some output based on {input_text!r}$"

--- a/scripts/run_unasync.py
+++ b/scripts/run_unasync.py
@@ -34,6 +34,7 @@ def main() -> None:
         "aclose": "close",
         "Async": "Sync",
         "obp_accounting_sdk._async.factory.os": "obp_accounting_sdk._sync.factory.os",
+        "create_async_periodic_task_manager": "create_sync_periodic_task_manager",
     }
     _run(
         fromdir="src/obp_accounting_sdk/_async/",

--- a/src/obp_accounting_sdk/_async/longrun.py
+++ b/src/obp_accounting_sdk/_async/longrun.py
@@ -279,5 +279,11 @@ class AsyncNullLongrunSession:
     ) -> None:
         """Cleanup when exiting the context manager."""
 
+    async def make_reservation(self) -> None:
+        """Make a reservation for the current job."""
+
     async def start(self) -> None:
         """Start accounting for the current job."""
+
+    async def finish(self) -> None:
+        """Finalize accounting session for the current job."""

--- a/src/obp_accounting_sdk/_async/longrun.py
+++ b/src/obp_accounting_sdk/_async/longrun.py
@@ -120,7 +120,7 @@ class AsyncLongrunSession:
             "proj_id": str(self._proj_id),
             "status": LongrunStatus.STARTED,
             "instances": str(self._instances),
-            "instance_type": "fargate",
+            "instance_type": self._instance_type,
             "timestamp": get_current_timestamp(),
         }
         try:

--- a/src/obp_accounting_sdk/_async/oneshot.py
+++ b/src/obp_accounting_sdk/_async/oneshot.py
@@ -74,7 +74,7 @@ class AsyncOneshotSession:
             L.info("Overriding previous name value '%s' with '%s'", self.name, value)
         self._name = value
 
-    async def _make_reservation(self) -> None:
+    async def make_reservation(self) -> None:
         """Make a new reservation."""
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
@@ -108,6 +108,9 @@ class AsyncOneshotSession:
         except Exception as exc:
             errmsg = "Error while parsing the response"
             raise AccountingReservationError(message=errmsg) from exc
+
+    async def start(self) -> None:
+        """Start accounting for the current job. Not used for Oneshot jobs."""
 
     async def _cancel_reservation(self) -> None:
         """Cancel the reservation."""
@@ -154,9 +157,24 @@ class AsyncOneshotSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
+    async def finish(
+        self,
+        exc_type: type[BaseException] | None = None,
+        _exc_val: BaseException | None = None,
+        _exc_tb: TracebackType | None = None,
+    ) -> None:
+        if exc_type is None:
+            await self._send_usage()
+        else:
+            L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
+            try:
+                await self._cancel_reservation()
+            except AccountingCancellationError as ex:
+                L.warning("Error while cancelling the reservation: %r", ex)
+
     async def __aenter__(self) -> Self:
         """Initialize when entering the context manager."""
-        await self._make_reservation()
+        await self.make_reservation()
         return self
 
     async def __aexit__(
@@ -166,14 +184,7 @@ class AsyncOneshotSession:
         exc_tb: TracebackType | None,
     ) -> None:
         """Cleanup when exiting the context manager."""
-        if exc_type is None:
-            await self._send_usage()
-        else:
-            L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
-            try:
-                await self._cancel_reservation()
-            except AccountingCancellationError as ex:
-                L.warning("Error while cancelling the reservation: %r", ex)
+        await self.finish(exc_type, exc_val, exc_tb)
 
 
 class AsyncNullOneshotSession:

--- a/src/obp_accounting_sdk/_async/oneshot.py
+++ b/src/obp_accounting_sdk/_async/oneshot.py
@@ -205,3 +205,12 @@ class AsyncNullOneshotSession:
         exc_tb: TracebackType | None,
     ) -> None:
         """Cleanup when exiting the context manager."""
+
+    async def make_reservation(self) -> None:
+        """Make a reservation for the current job."""
+
+    async def start(self) -> None:
+        """Start accounting for the current job."""
+
+    async def finish(self) -> None:
+        """Finalize accounting session for the current job."""

--- a/src/obp_accounting_sdk/_sync/longrun.py
+++ b/src/obp_accounting_sdk/_sync/longrun.py
@@ -1,19 +1,14 @@
 """Longrun session."""
 
 import logging
-import platform
-import signal
-import time
 from http import HTTPStatus
-from multiprocessing import get_context
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 from uuid import UUID
 
 import httpx
 
 from obp_accounting_sdk.constants import (
-    HEARTBEAT_INTERVAL,
     MAX_JOB_NAME_LENGTH,
     LongrunStatus,
     ServiceSubtype,
@@ -25,10 +20,7 @@ from obp_accounting_sdk.errors import (
     AccountingUsageError,
     InsufficientFundsError,
 )
-from obp_accounting_sdk.utils import get_current_timestamp
-
-if TYPE_CHECKING:
-    from multiprocessing.process import BaseProcess
+from obp_accounting_sdk.utils import create_sync_periodic_task_manager, get_current_timestamp
 
 L = logging.getLogger(__name__)
 
@@ -47,6 +39,7 @@ class SyncLongrunSession:
         instance_type: str,
         duration: int,
         name: str | None = None,
+        job_id: UUID | None = None,
     ) -> None:
         """Initialization."""
         self._http_client = http_client
@@ -55,13 +48,13 @@ class SyncLongrunSession:
         self._service_subtype: ServiceSubtype = ServiceSubtype(subtype)
         self._proj_id: UUID = UUID(str(proj_id))
         self._user_id: UUID = UUID(str(user_id))
-        self._job_id: UUID | None = None
+        self._job_id: UUID | None = job_id
         self._name = name
         self._job_running: bool = False
         self._instances: int = instances
         self._instance_type: str = instance_type
         self._duration: int = duration
-        self._heartbeat_sender_process: BaseProcess | None = None
+        self._cancel_heartbeat_sender: Any | None = None
 
     @property
     def name(self) -> str | None:
@@ -78,7 +71,7 @@ class SyncLongrunSession:
             L.info("Overriding previous name value '%s' with '%s'", self.name, value)
         self._name = value
 
-    def _make_reservation(self) -> None:
+    def make_reservation(self) -> None:
         """Make a new reservation."""
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
@@ -159,7 +152,7 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
-    def _send_heartbeat(self, http_sync_client: httpx.Client) -> None:
+    def _send_heartbeat(self) -> None:
         """Send heartbeat event to accounting."""
         if self._job_id is None:
             errmsg = "Cannot send heartbeat before making a successful reservation"
@@ -175,7 +168,7 @@ class SyncLongrunSession:
             "timestamp": get_current_timestamp(),
         }
         try:
-            response = http_sync_client.post(f"{self._base_url}/usage/longrun", json=data)
+            response = self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
             response.raise_for_status()
         except httpx.RequestError as exc:
             errmsg = f"Error in request {exc.request.method} {exc.request.url}"
@@ -184,24 +177,6 @@ class SyncLongrunSession:
             status_code = exc.response.status_code
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
-
-    def _heartbeat_sender_loop(self) -> None:
-        """Periodically send a signal to the accounting service that the job is still alive."""
-        running = True
-
-        def signal_handler(_signum: int, _frame: Any) -> None:
-            nonlocal running
-            running = False
-
-        signal.signal(signal.SIGTERM, signal_handler)
-
-        with httpx.Client() as http_sync_client:
-            while running:
-                try:
-                    time.sleep(HEARTBEAT_INTERVAL)
-                    self._send_heartbeat(http_sync_client)
-                except RuntimeError as exc:
-                    L.error("Error in heartbeat sender: %s", exc)
 
     def start(self) -> None:
         """Start accounting for the current job."""
@@ -229,32 +204,24 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
-        # For some reason child process is hanging when using default spawn method on MacOS.
-        # TODO: investigate further and remove this workaround.
-        ctx = get_context("fork") if platform.system() != "Linux" else get_context()
-
-        self._heartbeat_sender_process = ctx.Process(
-            target=self._heartbeat_sender_loop,
-            daemon=True,
-        )
-        self._heartbeat_sender_process.start()
+        self._cancel_heartbeat_sender = create_sync_periodic_task_manager(self._send_heartbeat)
         self._job_running = True
 
     def __enter__(self) -> Self:
         """Initialize when entering the context manager."""
-        self._make_reservation()
+        if self._job_id is None:
+            self.make_reservation()
         return self
 
-    def __exit__(
+    def finish(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
         """Cleanup when exiting the context manager."""
-        if self._heartbeat_sender_process:
-            self._heartbeat_sender_process.terminate()
-            self._heartbeat_sender_process.join()
+        if self._cancel_heartbeat_sender:
+            self._cancel_heartbeat_sender()
 
         if not self._job_running and exc_type:
             L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
@@ -280,6 +247,14 @@ class SyncLongrunSession:
                 self._finish()
             except AccountingUsageError as ex:
                 L.error("Error while finishing the job: %r", ex)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.finish(exc_type=exc_type, exc_val=exc_val, exc_tb=exc_tb)
 
 
 class SyncNullLongrunSession:

--- a/src/obp_accounting_sdk/_sync/longrun.py
+++ b/src/obp_accounting_sdk/_sync/longrun.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import httpx
 
 from obp_accounting_sdk.constants import (
+    HEARTBEAT_INTERVAL,
     MAX_JOB_NAME_LENGTH,
     LongrunStatus,
     ServiceSubtype,
@@ -204,7 +205,9 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
-        self._cancel_heartbeat_sender = create_sync_periodic_task_manager(self._send_heartbeat)
+        self._cancel_heartbeat_sender = create_sync_periodic_task_manager(
+            self._send_heartbeat, HEARTBEAT_INTERVAL
+        )
         self._job_running = True
 
     def __enter__(self) -> Self:
@@ -215,9 +218,9 @@ class SyncLongrunSession:
 
     def finish(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        _exc_tb: TracebackType | None,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        _exc_tb: TracebackType | None = None,
     ) -> None:
         """Cleanup when exiting the context manager."""
         if self._cancel_heartbeat_sender:

--- a/src/obp_accounting_sdk/_sync/longrun.py
+++ b/src/obp_accounting_sdk/_sync/longrun.py
@@ -108,6 +108,37 @@ class SyncLongrunSession:
             errmsg = "Error while parsing the response"
             raise AccountingReservationError(message=errmsg) from exc
 
+    def start(self) -> None:
+        """Start accounting for the current job."""
+        if self._job_id is None:
+            errmsg = "Cannot send session before making a successful reservation"
+            raise RuntimeError(errmsg)
+        data = {
+            "type": self._service_type,
+            "subtype": self._service_subtype,
+            "job_id": str(self._job_id),
+            "proj_id": str(self._proj_id),
+            "status": LongrunStatus.STARTED,
+            "instances": str(self._instances),
+            "instance_type": "fargate",
+            "timestamp": get_current_timestamp(),
+        }
+        try:
+            response = self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
+            response.raise_for_status()
+        except httpx.RequestError as exc:
+            errmsg = f"Error in request {exc.request.method} {exc.request.url}"
+            raise AccountingUsageError(message=errmsg) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
+            raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
+
+        self._cancel_heartbeat_sender = create_sync_periodic_task_manager(
+            self._send_heartbeat, HEARTBEAT_INTERVAL
+        )
+        self._job_running = True
+
     def _cancel_reservation(self) -> None:
         """Cancel the reservation."""
         if self._job_id is None:
@@ -179,37 +210,6 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
-    def start(self) -> None:
-        """Start accounting for the current job."""
-        if self._job_id is None:
-            errmsg = "Cannot send session before making a successful reservation"
-            raise RuntimeError(errmsg)
-        data = {
-            "type": self._service_type,
-            "subtype": self._service_subtype,
-            "job_id": str(self._job_id),
-            "proj_id": str(self._proj_id),
-            "status": LongrunStatus.STARTED,
-            "instances": str(self._instances),
-            "instance_type": "fargate",
-            "timestamp": get_current_timestamp(),
-        }
-        try:
-            response = self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
-            response.raise_for_status()
-        except httpx.RequestError as exc:
-            errmsg = f"Error in request {exc.request.method} {exc.request.url}"
-            raise AccountingUsageError(message=errmsg) from exc
-        except httpx.HTTPStatusError as exc:
-            status_code = exc.response.status_code
-            errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
-            raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
-
-        self._cancel_heartbeat_sender = create_sync_periodic_task_manager(
-            self._send_heartbeat, HEARTBEAT_INTERVAL
-        )
-        self._job_running = True
-
     def __enter__(self) -> Self:
         """Initialize when entering the context manager."""
         if self._job_id is None:
@@ -279,5 +279,11 @@ class SyncNullLongrunSession:
     ) -> None:
         """Cleanup when exiting the context manager."""
 
+    def make_reservation(self) -> None:
+        """Make a reservation for the current job."""
+
     def start(self) -> None:
         """Start accounting for the current job."""
+
+    def finish(self) -> None:
+        """Finalize accounting session for the current job."""

--- a/src/obp_accounting_sdk/_sync/longrun.py
+++ b/src/obp_accounting_sdk/_sync/longrun.py
@@ -217,7 +217,7 @@ class SyncLongrunSession:
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        _exc_tb: TracebackType | None,
     ) -> None:
         """Cleanup when exiting the context manager."""
         if self._cancel_heartbeat_sender:
@@ -252,9 +252,9 @@ class SyncLongrunSession:
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        _exc_tb: TracebackType | None,
     ) -> None:
-        self.finish(exc_type=exc_type, exc_val=exc_val, exc_tb=exc_tb)
+        self.finish(exc_type, exc_val, _exc_tb)
 
 
 class SyncNullLongrunSession:
@@ -270,9 +270,9 @@ class SyncNullLongrunSession:
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: TracebackType | None,
     ) -> None:
         """Cleanup when exiting the context manager."""
 

--- a/src/obp_accounting_sdk/_sync/longrun.py
+++ b/src/obp_accounting_sdk/_sync/longrun.py
@@ -120,7 +120,7 @@ class SyncLongrunSession:
             "proj_id": str(self._proj_id),
             "status": LongrunStatus.STARTED,
             "instances": str(self._instances),
-            "instance_type": "fargate",
+            "instance_type": self._instance_type,
             "timestamp": get_current_timestamp(),
         }
         try:

--- a/src/obp_accounting_sdk/constants.py
+++ b/src/obp_accounting_sdk/constants.py
@@ -4,7 +4,8 @@ import os
 from enum import StrEnum, auto
 
 MAX_JOB_NAME_LENGTH = 255
-HEARTBEAT_INTERVAL = int(os.getenv("ACCOUNTING_HEARTBEAT_INTERVAL", "60"))
+
+HEARTBEAT_INTERVAL = int(os.getenv("ACCOUNTING_HEARTBEAT_INTERVAL", "30"))
 
 
 class HyphenStrEnum(StrEnum):

--- a/src/obp_accounting_sdk/utils.py
+++ b/src/obp_accounting_sdk/utils.py
@@ -1,8 +1,105 @@
 """Common utilities."""
 
+import asyncio
+import logging
+import platform
 import time
+from collections.abc import Callable, Coroutine
+from multiprocessing import get_context
+from typing import Any
+
+from obp_accounting_sdk.constants import HEARTBEAT_INTERVAL
+
+L = logging.getLogger(__name__)
 
 
 def get_current_timestamp() -> str:
     """Return the current timestamp in seconds formatted as string."""
     return str(int(time.time()))
+
+
+def create_cancellable_async_task(fn: Coroutine[Any, Any, Any]) -> Callable[[], Any]:
+    """Create an async task that can be cancelled.
+
+    Args:
+        fn: The coroutine to run as a task.
+
+    Returns:
+        A callable that cancels the task when called.
+    """
+    task = asyncio.create_task(fn)
+    return task.cancel
+
+
+def create_cancellable_sync_task(fn: Callable[[], None]) -> Callable[[], None]:
+    """Create a synchronous task that can be cancelled.
+
+    Args:
+        fn: The function to run in a separate process.
+
+    Returns:
+        A callable that terminates the process when called.
+    """
+    ctx = get_context("fork") if platform.system() != "Linux" else get_context()
+
+    process = ctx.Process(
+        target=fn,
+        daemon=True,
+    )
+    process.start()
+
+    def cancel() -> None:
+        process.terminate()
+        process.join()
+
+    return cancel
+
+
+def create_async_periodic_task_manager(callback: Callable[[], Any]) -> Callable[[], None]:
+    """Create a periodic task manager that periodically calls the callback.
+
+    Args:
+        callback: The callback function to call periodically.
+
+    Returns:
+        A callable that cancels the heartbeat when called.
+    """
+
+    async def heartbeat_loop() -> None:
+        """Async heartbeat loop."""
+        while True:
+            try:
+                await asyncio.sleep(HEARTBEAT_INTERVAL)
+                await callback()
+            except RuntimeError as exc:
+                L.error("Error in heartbeat sender: %s", exc)
+            except asyncio.CancelledError:
+                L.debug("Heartbeat sender loop cancelled")
+                break
+
+    return create_cancellable_async_task(heartbeat_loop())
+
+
+def create_sync_periodic_task_manager(callback: Callable[[], None]) -> Callable[[], None]:
+    """Create a synchronous heartbeat manager that periodically calls the callback.
+
+    Args:
+        callback: The callback function to call periodically.
+
+    Returns:
+        A callable that cancels the heartbeat when called.
+    """
+
+    def heartbeat_loop() -> None:
+        """Sync heartbeat loop."""
+        while True:
+            try:
+                time.sleep(HEARTBEAT_INTERVAL)
+                callback()
+            except RuntimeError as exc:
+                L.error("Error in heartbeat sender: %s", exc)
+            except Exception as exc:
+                L.error("Error in heartbeat sender: %s", exc)
+                break
+
+    return create_cancellable_sync_task(heartbeat_loop)

--- a/tests/_async/test_longrun.py
+++ b/tests/_async/test_longrun.py
@@ -274,9 +274,9 @@ async def test_longrun_session_improperly_used(httpx_mock):
         )
         # with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
         #     await session._cancel_reservation()
-        await session._make_reservation()
+        await session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
-            await session._make_reservation()
+            await session.make_reservation()
 
 
 async def test_longrun_session_with_application_error(httpx_mock, caplog):

--- a/tests/_async/test_oneshot.py
+++ b/tests/_async/test_oneshot.py
@@ -242,9 +242,9 @@ async def test_oneshot_session_improperly_used(httpx_mock):
             await session._send_usage()
         with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
             await session._cancel_reservation()
-        await session._make_reservation()
+        await session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
-            await session._make_reservation()
+            await session.make_reservation()
 
 
 async def test_oneshot_session_with_application_error(httpx_mock, caplog):

--- a/tests/_sync/test_longrun.py
+++ b/tests/_sync/test_longrun.py
@@ -274,9 +274,9 @@ def test_longrun_session_improperly_used(httpx_mock):
         )
         # with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
         #     await session._cancel_reservation()
-        session._make_reservation()
+        session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
-            session._make_reservation()
+            session.make_reservation()
 
 
 def test_longrun_session_with_application_error(httpx_mock, caplog):

--- a/tests/_sync/test_oneshot.py
+++ b/tests/_sync/test_oneshot.py
@@ -242,9 +242,9 @@ def test_oneshot_session_improperly_used(httpx_mock):
             session._send_usage()
         with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
             session._cancel_reservation()
-        session._make_reservation()
+        session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
-            session._make_reservation()
+            session.make_reservation()
 
 
 def test_oneshot_session_with_application_error(httpx_mock, caplog):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import asyncio
 import multiprocessing
+import signal
+import threading
 import time
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -198,3 +200,242 @@ class TestSyncPeriodicTaskManager:
 
         # Should have some entries
         assert len(shared_list) >= 2
+
+    @staticmethod
+    def test_sync_periodic_task_manager_internal_loop_signal_handling():
+        """Test signal handling in the internal loop."""
+        call_count = 0
+
+        def callback():
+            nonlocal call_count
+            call_count += 1
+
+        # Mock the multiprocessing part to run the loop directly
+        with patch("obp_accounting_sdk.utils.create_cancellable_sync_task") as mock_create_task:
+            # Capture the start_loop function
+            start_loop_func = None
+
+            def capture_start_loop(func):
+                nonlocal start_loop_func
+                start_loop_func = func
+                return lambda: None  # Return a dummy cancel function
+
+            mock_create_task.side_effect = capture_start_loop
+
+            # Create the task manager
+            create_sync_periodic_task_manager(callback, 1)
+
+            # Verify the task was created
+            assert mock_create_task.called
+            assert start_loop_func is not None
+
+            # Test the signal handling by running the loop in a thread
+            with patch("signal.signal") as mock_signal:
+                loop_thread = threading.Thread(target=start_loop_func, daemon=True)
+                loop_thread.start()
+
+                # Give it a moment to start
+                time.sleep(0.1)
+
+                # Verify signal handlers were registered
+                assert mock_signal.call_count == 2
+                mock_signal.assert_any_call(signal.SIGTERM, mock_signal.call_args_list[0][0][1])
+                mock_signal.assert_any_call(signal.SIGINT, mock_signal.call_args_list[1][0][1])
+
+                # Get the signal handler
+                signal_handler = mock_signal.call_args_list[0][0][1]
+
+                # Simulate a signal
+                signal_handler(signal.SIGTERM, None)
+
+                # Wait for thread to finish
+                loop_thread.join(timeout=2)
+
+                # Thread should have finished
+                assert not loop_thread.is_alive()
+
+    @staticmethod
+    def test_sync_periodic_task_manager_internal_loop_exception_handling():
+        """Test exception handling in the internal loop."""
+        call_count = 0
+
+        def callback():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                error_msg = "Test error"
+                raise RuntimeError(error_msg)
+
+        # Mock the multiprocessing part to run the loop directly
+        with patch("obp_accounting_sdk.utils.create_cancellable_sync_task") as mock_create_task:
+            # Capture the start_loop function
+            start_loop_func = None
+
+            def capture_start_loop(func):
+                nonlocal start_loop_func
+                start_loop_func = func
+                return lambda: None  # Return a dummy cancel function
+
+            mock_create_task.side_effect = capture_start_loop
+
+            # Create the task manager
+            create_sync_periodic_task_manager(callback, 1)
+
+            # Mock the logger and run the loop with a short timeout
+            with (
+                patch("obp_accounting_sdk.utils.L.error") as mock_error,
+                patch("obp_accounting_sdk.utils.L.debug") as mock_debug,
+                patch("threading.Event") as mock_event_class,
+            ):
+                # Create a mock event that will timeout quickly
+                mock_event = Mock()
+                mock_event.is_set.side_effect = [False, False, True]  # Allow 2 loops then stop
+                mock_event.wait.side_effect = [False, False]  # Don't timeout, let callback run
+                mock_event_class.return_value = mock_event
+
+                # Run the loop
+                start_loop_func()
+
+                # Should have logged the error
+                mock_error.assert_called_once()
+                assert "Error in callback" in str(mock_error.call_args)
+
+                # Should have logged graceful exit
+                mock_debug.assert_called_with("Task loop exiting gracefully")
+
+    @staticmethod
+    def test_sync_periodic_task_manager_internal_loop_general_exception():
+        """Test general exception handling breaks the loop."""
+        call_count = 0
+
+        def callback():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                error_msg = "Test error"
+                raise ValueError(error_msg)
+
+        # Mock the multiprocessing part to run the loop directly
+        with patch("obp_accounting_sdk.utils.create_cancellable_sync_task") as mock_create_task:
+            # Capture the start_loop function
+            start_loop_func = None
+
+            def capture_start_loop(func):
+                nonlocal start_loop_func
+                start_loop_func = func
+                return lambda: None  # Return a dummy cancel function
+
+            mock_create_task.side_effect = capture_start_loop
+
+            # Create the task manager
+            create_sync_periodic_task_manager(callback, 1)
+
+            # Mock the logger and run the loop with a short timeout
+            with (
+                patch("obp_accounting_sdk.utils.L.error") as mock_error,
+                patch("obp_accounting_sdk.utils.L.debug") as mock_debug,
+                patch("threading.Event") as mock_event_class,
+            ):
+                # Create a mock event that will timeout quickly
+                mock_event = Mock()
+                mock_event.is_set.side_effect = [False, False, True]  # Allow 2 loops then stop
+                mock_event.wait.side_effect = [False, False]  # Don't timeout, let callback run
+                mock_event_class.return_value = mock_event
+
+                # Run the loop
+                start_loop_func()
+
+                # Should have logged the error
+                mock_error.assert_called_once()
+                assert "Error in callback" in str(mock_error.call_args)
+
+                # Should have logged graceful exit
+                mock_debug.assert_called_with("Task loop exiting gracefully")
+
+    @staticmethod
+    def test_sync_periodic_task_manager_internal_loop_normal_operation():
+        """Test normal operation of the internal loop."""
+        call_count = 0
+
+        def callback():
+            nonlocal call_count
+            call_count += 1
+
+        # Mock the multiprocessing part to run the loop directly
+        with patch("obp_accounting_sdk.utils.create_cancellable_sync_task") as mock_create_task:
+            # Capture the start_loop function
+            start_loop_func = None
+
+            def capture_start_loop(func):
+                nonlocal start_loop_func
+                start_loop_func = func
+                return lambda: None  # Return a dummy cancel function
+
+            mock_create_task.side_effect = capture_start_loop
+
+            # Create the task manager
+            create_sync_periodic_task_manager(callback, 1)
+
+            # Mock the logger and run the loop with a short timeout
+            with (
+                patch("obp_accounting_sdk.utils.L.debug") as mock_debug,
+                patch("threading.Event") as mock_event_class,
+            ):
+                # Create a mock event that will timeout quickly
+                mock_event = Mock()
+                mock_event.is_set.side_effect = [False, False, True]  # Allow 2 loops then stop
+                mock_event.wait.side_effect = [False, False]  # Don't timeout, let callback run
+                mock_event_class.return_value = mock_event
+
+                # Run the loop
+                start_loop_func()
+
+                # Should have called the callback twice
+                assert call_count == 2
+
+                # Should have logged graceful exit
+                mock_debug.assert_called_with("Task loop exiting gracefully")
+
+    @staticmethod
+    def test_sync_periodic_task_manager_internal_loop_shutdown_event():
+        """Test shutdown event handling in the internal loop."""
+        call_count = 0
+
+        def callback():
+            nonlocal call_count
+            call_count += 1
+
+        # Mock the multiprocessing part to run the loop directly
+        with patch("obp_accounting_sdk.utils.create_cancellable_sync_task") as mock_create_task:
+            # Capture the start_loop function
+            start_loop_func = None
+
+            def capture_start_loop(func):
+                nonlocal start_loop_func
+                start_loop_func = func
+                return lambda: None  # Return a dummy cancel function
+
+            mock_create_task.side_effect = capture_start_loop
+
+            # Create the task manager
+            create_sync_periodic_task_manager(callback, 1)
+
+            # Mock the logger and run the loop with shutdown event timeout
+            with (
+                patch("obp_accounting_sdk.utils.L.debug") as mock_debug,
+                patch("threading.Event") as mock_event_class,
+            ):
+                # Create a mock event that will timeout on wait
+                mock_event = Mock()
+                mock_event.is_set.side_effect = [False, True]  # One loop then stop
+                mock_event.wait.return_value = True  # Simulate timeout/shutdown
+                mock_event_class.return_value = mock_event
+
+                # Run the loop
+                start_loop_func()
+
+                # Should not have called the callback due to shutdown
+                assert call_count == 0
+
+                # Should have logged graceful exit
+                mock_debug.assert_called_with("Task loop exiting gracefully")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,200 @@
+import asyncio
+import multiprocessing
+import time
+from unittest.mock import patch
+
+import pytest
+
+from obp_accounting_sdk.utils import (
+    create_async_periodic_task_manager,
+    create_sync_periodic_task_manager,
+    get_current_timestamp,
+)
+
+
+def test_get_current_timestamp():
+    """Test get_current_timestamp returns current time as string."""
+    with patch("time.time", return_value=1234567890):
+        assert get_current_timestamp() == "1234567890"
+
+
+class TestAsyncPeriodicTaskManager:
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_async_periodic_task_manager_basic():
+        """Test basic functionality of async periodic task manager."""
+        call_count = 0
+
+        async def callback():
+            nonlocal call_count
+            call_count += 1
+
+        cancel_task = create_async_periodic_task_manager(callback, 0.1)
+
+        # Let it run for a bit
+        await asyncio.sleep(0.25)
+
+        # Cancel the task
+        cancel_task()
+
+        # Should have been called at least 2 times
+        assert call_count >= 2
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_async_periodic_task_manager_cancellation():
+        """Test that cancelling stops the task."""
+        call_count = 0
+
+        async def callback():
+            nonlocal call_count
+            call_count += 1
+
+        cancel_task = create_async_periodic_task_manager(callback, 0.1)
+
+        # Let it run for a bit
+        await asyncio.sleep(0.15)
+        initial_count = call_count
+
+        # Cancel the task
+        cancel_task()
+
+        # Wait a bit more
+        await asyncio.sleep(0.15)
+
+        # Count should not have increased significantly after cancellation
+        assert call_count <= initial_count + 1
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_async_periodic_task_manager_exception_handling():
+        """Test that exceptions in callback are handled gracefully."""
+        call_count = 0
+
+        async def callback():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                error_msg = "Test error"
+                raise RuntimeError(error_msg)
+
+        with patch("obp_accounting_sdk.utils.L.error") as mock_logger:
+            cancel_task = create_async_periodic_task_manager(callback, 0.1)
+
+            # Let it run for a bit
+            await asyncio.sleep(0.25)
+
+            # Cancel the task
+            cancel_task()
+
+            # Should have logged the error
+            mock_logger.assert_called_once()
+            assert "Error in callback" in str(mock_logger.call_args)
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_async_periodic_task_manager_cancelled_error():
+        """Test that CancelledError is handled gracefully."""
+        call_count = 0
+
+        async def callback():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise asyncio.CancelledError
+
+        with patch("obp_accounting_sdk.utils.L.debug") as mock_logger:
+            cancel_task = create_async_periodic_task_manager(callback, 0.1)
+
+            # Let it run for a bit
+            await asyncio.sleep(0.25)
+
+            # Cancel the task
+            cancel_task()
+
+            # Should have logged the cancellation
+            mock_logger.assert_called_with("Task loop cancelled")
+
+
+class TestSyncPeriodicTaskManager:
+    @staticmethod
+    def test_sync_periodic_task_manager_basic():
+        """Test basic functionality of sync periodic task manager."""
+        # Use a shared variable to track callback calls
+        call_count = multiprocessing.Value("i", 0)
+
+        def callback():
+            with call_count.get_lock():
+                call_count.value += 1
+
+        cancel_task = create_sync_periodic_task_manager(callback, 1)
+
+        # Let it run for a bit
+        time.sleep(2.5)
+
+        # Cancel the task
+        cancel_task()
+
+        # Should have been called at least 2 times
+        assert call_count.value >= 2
+
+    @staticmethod
+    def test_sync_periodic_task_manager_cancellation():
+        """Test that cancelling stops the task."""
+        # Use a shared variable to track callback calls
+        call_count = multiprocessing.Value("i", 0)
+
+        def callback():
+            with call_count.get_lock():
+                call_count.value += 1
+
+        cancel_task = create_sync_periodic_task_manager(callback, 1)
+
+        # Let it run for a bit
+        time.sleep(1.5)
+        initial_count = call_count.value
+
+        # Cancel the task
+        cancel_task()
+
+        # Wait a bit more
+        time.sleep(1.5)
+
+        # Count should not have increased significantly after cancellation
+        assert call_count.value <= initial_count + 1
+
+    @staticmethod
+    def test_sync_periodic_task_manager_returns_cancel_function():
+        """Test that the function returns a cancel function."""
+
+        def callback():
+            pass
+
+        cancel_task = create_sync_periodic_task_manager(callback, 1)
+
+        # Should return a callable
+        assert callable(cancel_task)
+
+        # Cancel immediately
+        cancel_task()
+
+    @staticmethod
+    def test_sync_periodic_task_manager_with_shared_state():
+        """Test sync periodic task manager with shared state."""
+        # Test that the process is actually created and can be cancelled
+        manager = multiprocessing.Manager()
+        shared_list = manager.list()
+
+        def callback():
+            shared_list.append(time.time())
+
+        cancel_task = create_sync_periodic_task_manager(callback, 1)
+
+        # Let it run for a bit
+        time.sleep(2.5)
+
+        # Cancel the task
+        cancel_task()
+
+        # Should have some entries
+        assert len(shared_list) >= 2


### PR DESCRIPTION
Changes:
* Move heartbeat loop management outside of code that is processed by unasync - so that we have different implementations with asyncio and multiprocessing.Process and threading events.
* Update the Longrun and Oneshot sessions to expose publicly `make_reservation` and `finish` methods so that they can be called without using context manager (this is useful in a case where reservation and start/finish are called from different places/services).
* Add empty `start` method to Oneshot session - so that the signatures are the same.
* Add sync and async longrun endpoint in the demo app.