### PR TITLE
Teach `longrun` to not automatically use a heartbeat thread

### DIFF
--- a/scripts/run_unasync.py
+++ b/scripts/run_unasync.py
@@ -29,6 +29,7 @@ def main() -> None:
         "AsyncOneshotSession": "OneshotSession",
         "AsyncNullOneshotSession": "NullOneshotSession",
         "AsyncAccountingSessionFactory": "AccountingSessionFactory",
+        "AsyncLongrunSessionWithHeartbeat": "LongrunSessionWithHeartbeat",
         "_async": "_sync",
         "aclosing": "closing",
         "aclose": "close",

--- a/src/obp_accounting_sdk/_async/factory.py
+++ b/src/obp_accounting_sdk/_async/factory.py
@@ -5,7 +5,11 @@ import os
 
 import httpx
 
-from obp_accounting_sdk._async.longrun import AsyncLongrunSession, AsyncNullLongrunSession
+from obp_accounting_sdk._async.longrun import (
+    AsyncLongrunSession,
+    AsyncLongrunSessionWithHeartbeat,
+    AsyncNullLongrunSession,
+)
 from obp_accounting_sdk._async.oneshot import AsyncNullOneshotSession, AsyncOneshotSession
 
 L = logging.getLogger(__name__)
@@ -52,11 +56,21 @@ class AsyncAccountingSessionFactory:
             raise RuntimeError(errmsg)
         return AsyncOneshotSession(http_client=self._http_client, base_url=self._base_url, **kwargs)
 
-    def longrun_session(self, **kwargs) -> AsyncLongrunSession | AsyncNullLongrunSession:
+    def longrun_session(
+        self,
+        disable_heartbeat: bool = False,  # noqa: FBT001, FBT002
+        **kwargs,
+    ) -> AsyncLongrunSession | AsyncNullLongrunSession:
         """Return a new longrun session."""
         if self._disabled:
             return AsyncNullLongrunSession()
         if not self._http_client:
             errmsg = "The internal http client is not set"
             raise RuntimeError(errmsg)
-        return AsyncLongrunSession(http_client=self._http_client, base_url=self._base_url, **kwargs)
+        if disable_heartbeat:
+            return AsyncLongrunSession(
+                http_client=self._http_client, base_url=self._base_url, **kwargs
+            )
+        return AsyncLongrunSessionWithHeartbeat(
+            http_client=self._http_client, base_url=self._base_url, **kwargs
+        )

--- a/src/obp_accounting_sdk/_async/longrun.py
+++ b/src/obp_accounting_sdk/_async/longrun.py
@@ -47,6 +47,8 @@ class AsyncLongrunSession:
         instance_type: str,
         duration: int,
         name: str | None = None,
+        job_id: UUID | None = None,
+        job_running: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
         """Initialization."""
         self._http_client = http_client
@@ -55,13 +57,12 @@ class AsyncLongrunSession:
         self._service_subtype: ServiceSubtype = ServiceSubtype(subtype)
         self._proj_id: UUID = UUID(str(proj_id))
         self._user_id: UUID = UUID(str(user_id))
-        self._job_id: UUID | None = None
+        self._job_id: UUID | None = job_id
         self._name = name
-        self._job_running: bool = False
+        self._job_running: bool = job_running
         self._instances: int = instances
         self._instance_type: str = instance_type
         self._duration: int = duration
-        self._heartbeat_sender_process: BaseProcess | None = None
 
     @property
     def name(self) -> str | None:
@@ -78,7 +79,7 @@ class AsyncLongrunSession:
             L.info("Overriding previous name value '%s' with '%s'", self.name, value)
         self._name = value
 
-    async def _make_reservation(self) -> None:
+    async def make_reservation(self) -> None:
         """Make a new reservation."""
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
@@ -114,7 +115,7 @@ class AsyncLongrunSession:
             errmsg = "Error while parsing the response"
             raise AccountingReservationError(message=errmsg) from exc
 
-    async def _cancel_reservation(self) -> None:
+    async def cancel_reservation(self) -> None:
         """Cancel the reservation."""
         if self._job_id is None:
             errmsg = "Cannot cancel a reservation without a job id"
@@ -132,7 +133,7 @@ class AsyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingCancellationError(message=errmsg, http_status_code=status_code) from exc
 
-    async def _finish(self) -> None:
+    async def finish(self) -> None:
         """Send a session closure event to accounting."""
         if self._job_id is None:
             errmsg = "Cannot close session before making a successful reservation"
@@ -159,10 +160,13 @@ class AsyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
-    def _send_heartbeat(self, http_sync_client: httpx.Client) -> None:
+    def send_heartbeat(self, http_sync_client: httpx.Client) -> None:
         """Send heartbeat event to accounting."""
         if self._job_id is None:
             errmsg = "Cannot send heartbeat before making a successful reservation"
+            raise RuntimeError(errmsg)
+        if not self._job_running:
+            errmsg = "Cannot send heartbeat before starting job"
             raise RuntimeError(errmsg)
         data = {
             "type": self._service_type,
@@ -185,6 +189,76 @@ class AsyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
+    async def start(self) -> None:
+        """Start accounting for the current job."""
+        if self._job_id is None:
+            errmsg = "Cannot send session before making a successful reservation"
+            raise RuntimeError(errmsg)
+        data = {
+            "type": self._service_type,
+            "subtype": self._service_subtype,
+            "job_id": str(self._job_id),
+            "proj_id": str(self._proj_id),
+            "status": LongrunStatus.STARTED,
+            "instances": str(self._instances),
+            "instance_type": self._instance_type,
+            "timestamp": get_current_timestamp(),
+        }
+        try:
+            response = await self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
+            response.raise_for_status()
+        except httpx.RequestError as exc:
+            errmsg = f"Error in request {exc.request.method} {exc.request.url}"
+            raise AccountingUsageError(message=errmsg) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
+            raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
+        self._job_running = True
+
+    async def __aenter__(self) -> Self:
+        """Initialize when entering the context manager."""
+        await self.make_reservation()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Cleanup when exiting the context manager."""
+        if not self._job_running and exc_type:
+            L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
+            try:
+                await self.cancel_reservation()
+            except AccountingCancellationError as ex:
+                L.warning("Error while cancelling the reservation: %r", ex)
+
+        elif not self._job_running and not exc_val:
+            errmsg = "Accounting session must be started before closing."
+            raise RuntimeError(errmsg)
+
+        elif self._job_running and exc_type:
+            # TODO: Consider refunding the user
+            try:
+                await self.finish()
+            except AccountingUsageError as ex:
+                L.error("Error while finishing the job: %r", ex)
+
+        else:
+            try:
+                L.debug("Finishing the job")
+                await self.finish()
+            except AccountingUsageError as ex:
+                L.error("Error while finishing the job: %r", ex)
+
+
+class AsyncLongrunSessionWithHeartbeat(AsyncLongrunSession):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._heartbeat_sender_process: BaseProcess | None = None
+
     def _heartbeat_sender_loop(self) -> None:
         """Periodically send a signal to the accounting service that the job is still alive."""
         running = True
@@ -199,36 +273,12 @@ class AsyncLongrunSession:
             while running:
                 try:
                     time.sleep(HEARTBEAT_INTERVAL)
-                    self._send_heartbeat(http_sync_client)
+                    self.send_heartbeat(http_sync_client)
                 except RuntimeError as exc:
                     L.error("Error in heartbeat sender: %s", exc)
 
     async def start(self) -> None:
-        """Start accounting for the current job."""
-        if self._job_id is None:
-            errmsg = "Cannot send session before making a successful reservation"
-            raise RuntimeError(errmsg)
-        data = {
-            "type": self._service_type,
-            "subtype": self._service_subtype,
-            "job_id": str(self._job_id),
-            "proj_id": str(self._proj_id),
-            "status": LongrunStatus.STARTED,
-            "instances": str(self._instances),
-            "instance_type": "fargate",
-            "timestamp": get_current_timestamp(),
-        }
-        try:
-            response = await self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
-            response.raise_for_status()
-        except httpx.RequestError as exc:
-            errmsg = f"Error in request {exc.request.method} {exc.request.url}"
-            raise AccountingUsageError(message=errmsg) from exc
-        except httpx.HTTPStatusError as exc:
-            status_code = exc.response.status_code
-            errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
-            raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
-
+        await super().start()
         # For some reason child process is hanging when using default spawn method on MacOS.
         # TODO: investigate further and remove this workaround.
         ctx = get_context("fork") if platform.system() != "Linux" else get_context()
@@ -238,12 +288,6 @@ class AsyncLongrunSession:
             daemon=True,
         )
         self._heartbeat_sender_process.start()
-        self._job_running = True
-
-    async def __aenter__(self) -> Self:
-        """Initialize when entering the context manager."""
-        await self._make_reservation()
-        return self
 
     async def __aexit__(
         self,
@@ -255,31 +299,7 @@ class AsyncLongrunSession:
         if self._heartbeat_sender_process:
             self._heartbeat_sender_process.terminate()
             self._heartbeat_sender_process.join()
-
-        if not self._job_running and exc_type:
-            L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
-            try:
-                await self._cancel_reservation()
-            except AccountingCancellationError as ex:
-                L.warning("Error while cancelling the reservation: %r", ex)
-
-        elif not self._job_running and not exc_val:
-            errmsg = "Accounting session must be started before closing."
-            raise RuntimeError(errmsg)
-
-        elif self._job_running and exc_type:
-            # TODO: Consider refunding the user
-            try:
-                await self._finish()
-            except AccountingUsageError as ex:
-                L.error("Error while finishing the job: %r", ex)
-
-        else:
-            try:
-                L.debug("Finishing the job")
-                await self._finish()
-            except AccountingUsageError as ex:
-                L.error("Error while finishing the job: %r", ex)
+        await super().__aexit__(exc_type, exc_val, exc_tb)
 
 
 class AsyncNullLongrunSession:

--- a/src/obp_accounting_sdk/_sync/factory.py
+++ b/src/obp_accounting_sdk/_sync/factory.py
@@ -5,7 +5,11 @@ import os
 
 import httpx
 
-from obp_accounting_sdk._sync.longrun import SyncLongrunSession, SyncNullLongrunSession
+from obp_accounting_sdk._sync.longrun import (
+    LongrunSessionWithHeartbeat,
+    SyncLongrunSession,
+    SyncNullLongrunSession,
+)
 from obp_accounting_sdk._sync.oneshot import NullOneshotSession, OneshotSession
 
 L = logging.getLogger(__name__)
@@ -52,11 +56,21 @@ class AccountingSessionFactory:
             raise RuntimeError(errmsg)
         return OneshotSession(http_client=self._http_client, base_url=self._base_url, **kwargs)
 
-    def longrun_session(self, **kwargs) -> SyncLongrunSession | SyncNullLongrunSession:
+    def longrun_session(
+        self,
+        disable_heartbeat: bool = False,  # noqa: FBT001, FBT002
+        **kwargs,
+    ) -> SyncLongrunSession | SyncNullLongrunSession:
         """Return a new longrun session."""
         if self._disabled:
             return SyncNullLongrunSession()
         if not self._http_client:
             errmsg = "The internal http client is not set"
             raise RuntimeError(errmsg)
-        return SyncLongrunSession(http_client=self._http_client, base_url=self._base_url, **kwargs)
+        if disable_heartbeat:
+            return SyncLongrunSession(
+                http_client=self._http_client, base_url=self._base_url, **kwargs
+            )
+        return LongrunSessionWithHeartbeat(
+            http_client=self._http_client, base_url=self._base_url, **kwargs
+        )

--- a/src/obp_accounting_sdk/_sync/longrun.py
+++ b/src/obp_accounting_sdk/_sync/longrun.py
@@ -47,6 +47,8 @@ class SyncLongrunSession:
         instance_type: str,
         duration: int,
         name: str | None = None,
+        job_id: UUID | None = None,
+        job_running: bool = False,  # noqa: FBT001, FBT002
     ) -> None:
         """Initialization."""
         self._http_client = http_client
@@ -55,13 +57,12 @@ class SyncLongrunSession:
         self._service_subtype: ServiceSubtype = ServiceSubtype(subtype)
         self._proj_id: UUID = UUID(str(proj_id))
         self._user_id: UUID = UUID(str(user_id))
-        self._job_id: UUID | None = None
+        self._job_id: UUID | None = job_id
         self._name = name
-        self._job_running: bool = False
+        self._job_running: bool = job_running
         self._instances: int = instances
         self._instance_type: str = instance_type
         self._duration: int = duration
-        self._heartbeat_sender_process: BaseProcess | None = None
 
     @property
     def name(self) -> str | None:
@@ -78,7 +79,7 @@ class SyncLongrunSession:
             L.info("Overriding previous name value '%s' with '%s'", self.name, value)
         self._name = value
 
-    def _make_reservation(self) -> None:
+    def make_reservation(self) -> None:
         """Make a new reservation."""
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
@@ -114,7 +115,7 @@ class SyncLongrunSession:
             errmsg = "Error while parsing the response"
             raise AccountingReservationError(message=errmsg) from exc
 
-    def _cancel_reservation(self) -> None:
+    def cancel_reservation(self) -> None:
         """Cancel the reservation."""
         if self._job_id is None:
             errmsg = "Cannot cancel a reservation without a job id"
@@ -132,7 +133,7 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingCancellationError(message=errmsg, http_status_code=status_code) from exc
 
-    def _finish(self) -> None:
+    def finish(self) -> None:
         """Send a session closure event to accounting."""
         if self._job_id is None:
             errmsg = "Cannot close session before making a successful reservation"
@@ -159,10 +160,13 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
-    def _send_heartbeat(self, http_sync_client: httpx.Client) -> None:
+    def send_heartbeat(self, http_sync_client: httpx.Client) -> None:
         """Send heartbeat event to accounting."""
         if self._job_id is None:
             errmsg = "Cannot send heartbeat before making a successful reservation"
+            raise RuntimeError(errmsg)
+        if not self._job_running:
+            errmsg = "Cannot send heartbeat before starting job"
             raise RuntimeError(errmsg)
         data = {
             "type": self._service_type,
@@ -185,6 +189,76 @@ class SyncLongrunSession:
             errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
             raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
 
+    def start(self) -> None:
+        """Start accounting for the current job."""
+        if self._job_id is None:
+            errmsg = "Cannot send session before making a successful reservation"
+            raise RuntimeError(errmsg)
+        data = {
+            "type": self._service_type,
+            "subtype": self._service_subtype,
+            "job_id": str(self._job_id),
+            "proj_id": str(self._proj_id),
+            "status": LongrunStatus.STARTED,
+            "instances": str(self._instances),
+            "instance_type": self._instance_type,
+            "timestamp": get_current_timestamp(),
+        }
+        try:
+            response = self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
+            response.raise_for_status()
+        except httpx.RequestError as exc:
+            errmsg = f"Error in request {exc.request.method} {exc.request.url}"
+            raise AccountingUsageError(message=errmsg) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
+            raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
+        self._job_running = True
+
+    def __enter__(self) -> Self:
+        """Initialize when entering the context manager."""
+        self.make_reservation()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Cleanup when exiting the context manager."""
+        if not self._job_running and exc_type:
+            L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
+            try:
+                self.cancel_reservation()
+            except AccountingCancellationError as ex:
+                L.warning("Error while cancelling the reservation: %r", ex)
+
+        elif not self._job_running and not exc_val:
+            errmsg = "Accounting session must be started before closing."
+            raise RuntimeError(errmsg)
+
+        elif self._job_running and exc_type:
+            # TODO: Consider refunding the user
+            try:
+                self.finish()
+            except AccountingUsageError as ex:
+                L.error("Error while finishing the job: %r", ex)
+
+        else:
+            try:
+                L.debug("Finishing the job")
+                self.finish()
+            except AccountingUsageError as ex:
+                L.error("Error while finishing the job: %r", ex)
+
+
+class LongrunSessionWithHeartbeat(SyncLongrunSession):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._heartbeat_sender_process: BaseProcess | None = None
+
     def _heartbeat_sender_loop(self) -> None:
         """Periodically send a signal to the accounting service that the job is still alive."""
         running = True
@@ -199,36 +273,12 @@ class SyncLongrunSession:
             while running:
                 try:
                     time.sleep(HEARTBEAT_INTERVAL)
-                    self._send_heartbeat(http_sync_client)
+                    self.send_heartbeat(http_sync_client)
                 except RuntimeError as exc:
                     L.error("Error in heartbeat sender: %s", exc)
 
     def start(self) -> None:
-        """Start accounting for the current job."""
-        if self._job_id is None:
-            errmsg = "Cannot send session before making a successful reservation"
-            raise RuntimeError(errmsg)
-        data = {
-            "type": self._service_type,
-            "subtype": self._service_subtype,
-            "job_id": str(self._job_id),
-            "proj_id": str(self._proj_id),
-            "status": LongrunStatus.STARTED,
-            "instances": str(self._instances),
-            "instance_type": "fargate",
-            "timestamp": get_current_timestamp(),
-        }
-        try:
-            response = self._http_client.post(f"{self._base_url}/usage/longrun", json=data)
-            response.raise_for_status()
-        except httpx.RequestError as exc:
-            errmsg = f"Error in request {exc.request.method} {exc.request.url}"
-            raise AccountingUsageError(message=errmsg) from exc
-        except httpx.HTTPStatusError as exc:
-            status_code = exc.response.status_code
-            errmsg = f"Error in response to {exc.request.method} {exc.request.url}: {status_code}"
-            raise AccountingUsageError(message=errmsg, http_status_code=status_code) from exc
-
+        super().start()
         # For some reason child process is hanging when using default spawn method on MacOS.
         # TODO: investigate further and remove this workaround.
         ctx = get_context("fork") if platform.system() != "Linux" else get_context()
@@ -238,12 +288,6 @@ class SyncLongrunSession:
             daemon=True,
         )
         self._heartbeat_sender_process.start()
-        self._job_running = True
-
-    def __enter__(self) -> Self:
-        """Initialize when entering the context manager."""
-        self._make_reservation()
-        return self
 
     def __exit__(
         self,
@@ -255,31 +299,7 @@ class SyncLongrunSession:
         if self._heartbeat_sender_process:
             self._heartbeat_sender_process.terminate()
             self._heartbeat_sender_process.join()
-
-        if not self._job_running and exc_type:
-            L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
-            try:
-                self._cancel_reservation()
-            except AccountingCancellationError as ex:
-                L.warning("Error while cancelling the reservation: %r", ex)
-
-        elif not self._job_running and not exc_val:
-            errmsg = "Accounting session must be started before closing."
-            raise RuntimeError(errmsg)
-
-        elif self._job_running and exc_type:
-            # TODO: Consider refunding the user
-            try:
-                self._finish()
-            except AccountingUsageError as ex:
-                L.error("Error while finishing the job: %r", ex)
-
-        else:
-            try:
-                L.debug("Finishing the job")
-                self._finish()
-            except AccountingUsageError as ex:
-                L.error("Error while finishing the job: %r", ex)
+        super().__exit__(exc_type, exc_val, exc_tb)
 
 
 class SyncNullLongrunSession:

--- a/tests/_async/test_longrun.py
+++ b/tests/_async/test_longrun.py
@@ -37,7 +37,7 @@ async def test_longrun_session_success(httpx_mock):
     )
 
     async with httpx.AsyncClient() as http_client:
-        async with test_module.AsyncLongrunSession(
+        async with test_module.AsyncLongrunSessionWithHeartbeat(
             http_client=http_client,
             base_url=BASE_URL,
             subtype=ServiceSubtype.ML_LLM,
@@ -83,7 +83,7 @@ async def test_longrun_session_with_name(httpx_mock):
     )
 
     async with httpx.AsyncClient() as http_client:
-        async with test_module.AsyncLongrunSession(
+        async with test_module.AsyncLongrunSessionWithHeartbeat(
             http_client=http_client,
             base_url=BASE_URL,
             subtype=ServiceSubtype.ML_LLM,
@@ -107,7 +107,7 @@ async def test_longrun_session_with_insufficient_funds(httpx_mock):
     )
     async with httpx.AsyncClient() as http_client:
         with pytest.raises(InsufficientFundsError):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -128,7 +128,7 @@ async def test_longrun_session_with_payload_error(httpx_mock):
     )
     async with httpx.AsyncClient() as http_client:
         with pytest.raises(AccountingReservationError, match="Error while parsing the response"):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -152,7 +152,7 @@ async def test_longrun_session_with_reservation_timeout(httpx_mock):
             AccountingReservationError,
             match=f"Error in request POST {BASE_URL}/reservation/longrun",
         ):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -176,7 +176,7 @@ async def test_longrun_session_with_reservation_error(httpx_mock):
             AccountingReservationError,
             match=f"Error in response to POST {BASE_URL}/reservation/longrun: 400",
         ):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -209,7 +209,7 @@ async def test_longrun_session_with_usage_timeout(httpx_mock):
             AccountingUsageError,
             match=f"Error in request POST {BASE_URL}/usage/longrun",
         ):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -242,7 +242,7 @@ async def test_longrun_session_with_usage_error(httpx_mock):
             AccountingUsageError,
             match=f"Error in response to POST {BASE_URL}/usage/longrun: 400",
         ):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -262,7 +262,7 @@ async def test_longrun_session_improperly_used(httpx_mock):
         url=f"{BASE_URL}/reservation/longrun",
     )
     async with httpx.AsyncClient() as http_client:
-        session = test_module.AsyncLongrunSession(
+        session = test_module.AsyncLongrunSessionWithHeartbeat(
             http_client=http_client,
             base_url=BASE_URL,
             subtype=ServiceSubtype.ML_LLM,
@@ -274,9 +274,9 @@ async def test_longrun_session_improperly_used(httpx_mock):
         )
         # with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
         #     await session._cancel_reservation()
-        await session._make_reservation()
+        await session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
-            await session._make_reservation()
+            await session.make_reservation()
 
 
 async def test_longrun_session_with_application_error(httpx_mock, caplog):
@@ -296,7 +296,7 @@ async def test_longrun_session_with_application_error(httpx_mock, caplog):
 
     async with httpx.AsyncClient() as http_client:
         with pytest.raises(RuntimeError, match="Application error"):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -329,7 +329,7 @@ async def test_longrun_session_with_application_error_and_cancellation_error(htt
 
     async with httpx.AsyncClient() as http_client:
         with pytest.raises(Exception, match="Application error"):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -367,7 +367,7 @@ async def test_longrun_session_with_application_error_and_cancellation_timeout(h
 
     async with httpx.AsyncClient() as http_client:
         with pytest.raises(Exception, match="Application error"):
-            async with test_module.AsyncLongrunSession(
+            async with test_module.AsyncLongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -390,3 +390,112 @@ async def test_longrun_session_with_application_error_and_cancellation_timeout(h
 async def test_longrun_session_null_as_context_manager():
     async with test_module.AsyncNullLongrunSession() as session:
         assert session.instances == 0
+
+
+async def test_longrun_send_heartbeat(httpx_mock):
+    async with httpx.AsyncClient() as http_client:
+        session = test_module.AsyncLongrunSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            instances=10,
+            instance_type="ml.g4dn.xlarge",
+            duration=1000,
+        )
+        with pytest.raises(
+            RuntimeError, match="Cannot send heartbeat before making a successful reservation"
+        ):
+            with httpx.Client() as http_sync_client:
+                session.send_heartbeat(http_sync_client)
+
+        httpx_mock.add_response(
+            json={"message": "", "data": {"job_id": JOB_ID}},
+            method="POST",
+            url=f"{BASE_URL}/reservation/longrun",
+        )
+        await session.make_reservation()
+        with pytest.raises(RuntimeError, match="Cannot send heartbeat before starting job"):
+            with httpx.Client() as http_sync_client:
+                session.send_heartbeat(http_sync_client)
+
+        httpx_mock.add_response(
+            json={"message": "", "data": None},
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+            is_reusable=True,
+        )
+        await session.start()
+
+        with httpx.Client() as http_sync_client:
+            session.send_heartbeat(http_sync_client)
+
+        httpx_mock.reset()
+        httpx_mock.add_response(
+            status_code=500,
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+            is_reusable=True,
+        )
+        with httpx.Client() as http_sync_client:
+            with pytest.raises(AccountingUsageError, match="Error in response to"):
+                session.send_heartbeat(http_sync_client)
+
+        httpx_mock.reset()
+        httpx_mock.add_exception(
+            httpx.ReadTimeout("Unable to read within timeout"),
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+            is_reusable=True,
+        )
+        with httpx.Client() as http_sync_client:
+            with pytest.raises(AccountingUsageError, match="Error in request"):
+                session.send_heartbeat(http_sync_client)
+
+
+async def test_errors(httpx_mock):
+    async with httpx.AsyncClient() as http_client:
+        session = test_module.AsyncLongrunSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            instances=10,
+            instance_type="ml.g4dn.xlarge",
+            duration=1000,
+        )
+        # session not started
+        with pytest.raises(Exception, match="Cannot cancel a reservation without a job id"):
+            await session.cancel_reservation()
+
+        with pytest.raises(
+            Exception, match="Cannot close session before making a successful reservation"
+        ):
+            await session.finish()
+
+        httpx_mock.add_response(
+            json={"message": "", "data": {"job_id": JOB_ID}},
+            method="POST",
+            url=f"{BASE_URL}/reservation/longrun",
+        )
+        httpx_mock.add_exception(
+            httpx.ReadTimeout("Unable to read within timeout"),
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+        )
+
+        await session.make_reservation()
+        with pytest.raises(Exception, match="Error in request"):
+            await session.finish()
+
+        httpx_mock.reset()
+        httpx_mock.add_response(
+            status_code=500,
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+        )
+
+        with pytest.raises(AccountingUsageError, match="Error in response to"):
+            await session.finish()

--- a/tests/_sync/test_longrun.py
+++ b/tests/_sync/test_longrun.py
@@ -37,7 +37,7 @@ def test_longrun_session_success(httpx_mock):
     )
 
     with httpx.Client() as http_client:
-        with test_module.SyncLongrunSession(
+        with test_module.LongrunSessionWithHeartbeat(
             http_client=http_client,
             base_url=BASE_URL,
             subtype=ServiceSubtype.ML_LLM,
@@ -83,7 +83,7 @@ def test_longrun_session_with_name(httpx_mock):
     )
 
     with httpx.Client() as http_client:
-        with test_module.SyncLongrunSession(
+        with test_module.LongrunSessionWithHeartbeat(
             http_client=http_client,
             base_url=BASE_URL,
             subtype=ServiceSubtype.ML_LLM,
@@ -107,7 +107,7 @@ def test_longrun_session_with_insufficient_funds(httpx_mock):
     )
     with httpx.Client() as http_client:
         with pytest.raises(InsufficientFundsError):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -128,7 +128,7 @@ def test_longrun_session_with_payload_error(httpx_mock):
     )
     with httpx.Client() as http_client:
         with pytest.raises(AccountingReservationError, match="Error while parsing the response"):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -152,7 +152,7 @@ def test_longrun_session_with_reservation_timeout(httpx_mock):
             AccountingReservationError,
             match=f"Error in request POST {BASE_URL}/reservation/longrun",
         ):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -176,7 +176,7 @@ def test_longrun_session_with_reservation_error(httpx_mock):
             AccountingReservationError,
             match=f"Error in response to POST {BASE_URL}/reservation/longrun: 400",
         ):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -209,7 +209,7 @@ def test_longrun_session_with_usage_timeout(httpx_mock):
             AccountingUsageError,
             match=f"Error in request POST {BASE_URL}/usage/longrun",
         ):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -242,7 +242,7 @@ def test_longrun_session_with_usage_error(httpx_mock):
             AccountingUsageError,
             match=f"Error in response to POST {BASE_URL}/usage/longrun: 400",
         ):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -262,7 +262,7 @@ def test_longrun_session_improperly_used(httpx_mock):
         url=f"{BASE_URL}/reservation/longrun",
     )
     with httpx.Client() as http_client:
-        session = test_module.SyncLongrunSession(
+        session = test_module.LongrunSessionWithHeartbeat(
             http_client=http_client,
             base_url=BASE_URL,
             subtype=ServiceSubtype.ML_LLM,
@@ -274,9 +274,9 @@ def test_longrun_session_improperly_used(httpx_mock):
         )
         # with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
         #     await session._cancel_reservation()
-        session._make_reservation()
+        session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
-            session._make_reservation()
+            session.make_reservation()
 
 
 def test_longrun_session_with_application_error(httpx_mock, caplog):
@@ -296,7 +296,7 @@ def test_longrun_session_with_application_error(httpx_mock, caplog):
 
     with httpx.Client() as http_client:
         with pytest.raises(RuntimeError, match="Application error"):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -329,7 +329,7 @@ def test_longrun_session_with_application_error_and_cancellation_error(httpx_moc
 
     with httpx.Client() as http_client:
         with pytest.raises(Exception, match="Application error"):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -367,7 +367,7 @@ def test_longrun_session_with_application_error_and_cancellation_timeout(httpx_m
 
     with httpx.Client() as http_client:
         with pytest.raises(Exception, match="Application error"):
-            with test_module.SyncLongrunSession(
+            with test_module.LongrunSessionWithHeartbeat(
                 http_client=http_client,
                 base_url=BASE_URL,
                 subtype=ServiceSubtype.ML_LLM,
@@ -390,3 +390,112 @@ def test_longrun_session_with_application_error_and_cancellation_timeout(httpx_m
 def test_longrun_session_null_as_context_manager():
     with test_module.SyncNullLongrunSession() as session:
         assert session.instances == 0
+
+
+def test_longrun_send_heartbeat(httpx_mock):
+    with httpx.Client() as http_client:
+        session = test_module.SyncLongrunSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            instances=10,
+            instance_type="ml.g4dn.xlarge",
+            duration=1000,
+        )
+        with pytest.raises(
+            RuntimeError, match="Cannot send heartbeat before making a successful reservation"
+        ):
+            with httpx.Client() as http_sync_client:
+                session.send_heartbeat(http_sync_client)
+
+        httpx_mock.add_response(
+            json={"message": "", "data": {"job_id": JOB_ID}},
+            method="POST",
+            url=f"{BASE_URL}/reservation/longrun",
+        )
+        session.make_reservation()
+        with pytest.raises(RuntimeError, match="Cannot send heartbeat before starting job"):
+            with httpx.Client() as http_sync_client:
+                session.send_heartbeat(http_sync_client)
+
+        httpx_mock.add_response(
+            json={"message": "", "data": None},
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+            is_reusable=True,
+        )
+        session.start()
+
+        with httpx.Client() as http_sync_client:
+            session.send_heartbeat(http_sync_client)
+
+        httpx_mock.reset()
+        httpx_mock.add_response(
+            status_code=500,
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+            is_reusable=True,
+        )
+        with httpx.Client() as http_sync_client:
+            with pytest.raises(AccountingUsageError, match="Error in response to"):
+                session.send_heartbeat(http_sync_client)
+
+        httpx_mock.reset()
+        httpx_mock.add_exception(
+            httpx.ReadTimeout("Unable to read within timeout"),
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+            is_reusable=True,
+        )
+        with httpx.Client() as http_sync_client:
+            with pytest.raises(AccountingUsageError, match="Error in request"):
+                session.send_heartbeat(http_sync_client)
+
+
+def test_errors(httpx_mock):
+    with httpx.Client() as http_client:
+        session = test_module.SyncLongrunSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            instances=10,
+            instance_type="ml.g4dn.xlarge",
+            duration=1000,
+        )
+        # session not started
+        with pytest.raises(Exception, match="Cannot cancel a reservation without a job id"):
+            session.cancel_reservation()
+
+        with pytest.raises(
+            Exception, match="Cannot close session before making a successful reservation"
+        ):
+            session.finish()
+
+        httpx_mock.add_response(
+            json={"message": "", "data": {"job_id": JOB_ID}},
+            method="POST",
+            url=f"{BASE_URL}/reservation/longrun",
+        )
+        httpx_mock.add_exception(
+            httpx.ReadTimeout("Unable to read within timeout"),
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+        )
+
+        session.make_reservation()
+        with pytest.raises(Exception, match="Error in request"):
+            session.finish()
+
+        httpx_mock.reset()
+        httpx_mock.add_response(
+            status_code=500,
+            method="POST",
+            url=f"{BASE_URL}/usage/longrun",
+        )
+
+        with pytest.raises(AccountingUsageError, match="Error in response to"):
+            session.finish()


### PR DESCRIPTION
* in addition; allow the `AsyncLongrunSession` to be used without it being in a context manager: this allows `make_reservation` to be called when desired, instead of automatically
* the factory has the same API as before, and defaults to creating a thread
* change the constructor to allow for `job_id` and `job_running` to be passed in, to allow for new instances to be brought up without them automatically trying to register, or fail when calling things like `cancel_reservation`