### PR TITLE
Add neuron mesh skeletonization service subtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.2.2
+
+- Add service subtype for neuron mesh skeletonization.
+
 ## Version 0.2.1
 
 - Add service subtype for small circuit simulations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Version 0.2.2
-
-- Add service subtype for neuron mesh skeletonization.
-
 ## Version 0.2.1
 
 - Add service subtype for small circuit simulations.

--- a/src/obp_accounting_sdk/constants.py
+++ b/src/obp_accounting_sdk/constants.py
@@ -39,6 +39,7 @@ class ServiceSubtype(HyphenStrEnum):
     ML_LLM = auto()
     ML_RAG = auto()
     ML_RETRIEVAL = auto()
+    NEURON_MESH_SKELETONIZATION = auto()
     NOTEBOOK = auto()
     SINGLE_CELL_BUILD = auto()
     SINGLE_CELL_SIM = auto()


### PR DESCRIPTION
Relates to [Enable accounting for skeletonization](https://github.com/openbraininstitute/Ultraliser/issues/89).

@mgeplf I can wait for the [add ServiceSubtype for ClusterSimulation](https://github.com/openbraininstitute/accounting-sdk/pull/22) to be merged first.