### PR TITLE
Oneshot session improvements

### DIFF
--- a/src/obp_accounting_sdk/_async/oneshot.py
+++ b/src/obp_accounting_sdk/_async/oneshot.py
@@ -1,10 +1,59 @@
-"""Oneshot session."""
+"""Oneshot accounting sessions for single-use jobs.
+
+This module provides async oneshot session classes for reserving and tracking
+usage of short computational jobs against the accounting service.
+
+Two concrete implementations are available:
+
+- ``AsyncOneshotSession``: Communicates with the accounting HTTP API to reserve
+  budget, report usage, and cancel reservations.
+- ``AsyncNullOneshotSession``: A no-op implementation that satisfies the same
+  interface without making any HTTP calls. Useful for testing, local development,
+  or when accounting is disabled.
+
+Both classes share a common interface defined by ``AsyncBaseOneshotSession`` and
+can be used as async context managers or managed manually.
+
+Usage as a context manager:
+
+    async with AsyncOneshotSession(
+        http_client=client,
+        subtype=ServiceSubtype.ML_LLM,
+        proj_id="...",
+        user_id="...",
+        count=10,
+    ) as session:
+        # perform work
+        session.count = actual_count  # optionally adjust before exit
+
+On context exit, usage is automatically reported on success, or the reservation
+is cancelled if an unhandled exception occurs.
+
+Manual lifecycle management::
+
+    session = AsyncOneshotSession(
+        http_client=client,
+        subtype=ServiceSubtype.ML_LLM,
+        proj_id="...",
+        user_id="...",
+        count=10,
+    )
+    await session.make_reservation()
+    try:
+        # perform work
+        session.count = actual_count  # optionally adjust before finishing
+        await session.finish()
+    except Exception:
+        await session.cancel_reservation()
+        raise
+"""
 
 import logging
+from abc import ABC, abstractmethod
 from http import HTTPStatus
 from types import TracebackType
 from typing import Self
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 
@@ -20,8 +69,169 @@ from obp_accounting_sdk.utils import get_current_timestamp
 L = logging.getLogger(__name__)
 
 
-class AsyncOneshotSession:
-    """Oneshot Session."""
+class AsyncBaseOneshotSession(ABC):
+    """Abstract base class defining the interface for all oneshot sessions.
+
+    Subclasses must implement ``make_reservation``, ``start``, ``finish``, and
+    ``cancel_reservation``. Common properties (``job_id``, ``count``, ``name``)
+    and context manager behaviour are provided by this base class.
+
+    This class should not be instantiated directly. Use one of the concrete
+    implementations: ``AsyncOneshotSession`` or ``AsyncNullOneshotSession``.
+    """
+
+    def __init__(self, count: int, name: str | None = None) -> None:
+        """Initialize shared session state.
+
+        Args:
+            count: The number of units to reserve. Must be a non-negative integer.
+            name: Optional human-readable name for the job.
+        """
+        self._job_id: UUID | None = None
+        self._finished: bool = False
+        self._name = name
+        self._count = self.count = count
+
+    @property
+    def job_id(self) -> UUID | None:
+        """The unique identifier assigned to this job upon reservation.
+
+        Returns ``None`` before ``make_reservation`` is called. Read-only.
+        """
+        return self._job_id
+
+    @property
+    def count(self) -> int:
+        """The number of units to reserve or report as usage.
+
+        Can be updated after initialization but before ``finish`` is called,
+        allowing the actual usage to differ from the initial reservation.
+        """
+        return self._count
+
+    @count.setter
+    def count(self, value: int) -> None:
+        """Set the count value.
+
+        Raises:
+            ValueError: If set to a non-integer or negative value.
+        """
+        if not isinstance(value, int) or value < 0:  # pyright: ignore[reportUnnecessaryIsInstance]
+            errmsg = "count must be an integer >= 0"
+            raise ValueError(errmsg)
+        if self._count != value:
+            L.info("Overriding previous count value %s with %s", self._count, value)
+        self._count = value
+
+    @property
+    def name(self) -> str | None:
+        """Optional human-readable name for the job.
+
+        Can be set at initialization or updated afterwards. Maximum length is
+        defined by ``MAX_JOB_NAME_LENGTH``.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Set the job name.
+
+        Raises:
+            ValueError: If set to a non-string or a string exceeding the max length.
+        """
+        if not isinstance(value, str) or len(value) > MAX_JOB_NAME_LENGTH:  # pyright: ignore[reportUnnecessaryIsInstance]
+            errmsg = f"Job name must be a string with max length {MAX_JOB_NAME_LENGTH}"
+            raise ValueError(errmsg)
+        if self._name is not None and self._name != value:
+            L.info("Overriding previous name value '%s' with '%s'", self._name, value)
+        self._name = value
+
+    @abstractmethod
+    async def make_reservation(self) -> None:
+        """Reserve budget for a oneshot job.
+
+        Must be called exactly once before ``finish`` or ``cancel_reservation``.
+        After a successful call, ``job_id`` is set.
+
+        Raises:
+            RuntimeError: If called more than once.
+        """
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start accounting for the current job. Not used for oneshot jobs."""
+
+    @abstractmethod
+    async def finish(
+        self,
+        exc_type: type[BaseException] | None = None,
+        _exc_val: BaseException | None = None,
+        _exc_tb: TracebackType | None = None,
+    ) -> None:
+        """Finalize the session by reporting usage or cancelling on error.
+
+        When called without arguments (or with ``exc_type=None``), reports
+        successful usage. When called with exception info (as done automatically
+        by the context manager on unhandled errors), cancels the reservation.
+
+        After a successful finish, ``cancel_reservation`` can no longer be called.
+
+        Args:
+            exc_type: The exception type if finishing due to an error, or ``None``
+                for a successful finish.
+            _exc_val: The exception instance (used by the context manager protocol).
+            _exc_tb: The traceback (used by the context manager protocol).
+        """
+
+    @abstractmethod
+    async def cancel_reservation(self) -> None:
+        """Cancel the current reservation.
+
+        Releases the reserved budget without reporting usage. Cannot be called
+        after a successful ``finish``.
+
+        Raises:
+            RuntimeError: If called after ``finish`` completed successfully.
+        """
+
+    async def __aenter__(self) -> Self:
+        """Initialize when entering the context manager."""
+        await self.make_reservation()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Cleanup when exiting the context manager."""
+        await self.finish(exc_type, exc_val, exc_tb)
+
+
+class AsyncOneshotSession(AsyncBaseOneshotSession):
+    """Oneshot session that communicates with the accounting HTTP API.
+
+    Manages the full lifecycle of a oneshot job: reserving budget, reporting
+    usage on success, and cancelling the reservation on failure. Can be used
+    as an async context manager or managed manually.
+
+    Args:
+        http_client: An ``httpx.AsyncClient`` instance used for HTTP requests.
+        base_url: Root URL of the accounting service. Typically set via
+            environment variable and not customized at runtime.
+        subtype: The service subtype for this job (e.g. ``ServiceSubtype.ML_LLM``).
+        proj_id: The project identifier.
+        user_id: The user identifier.
+        count: The number of units to reserve. Can be adjusted before ``finish``.
+        name: Optional human-readable name for the job.
+
+    Raises:
+        InsufficientFundsError: If the project does not have enough budget.
+        AccountingReservationError: If the reservation request fails.
+        AccountingUsageError: If the usage report fails.
+        AccountingCancellationError: If the cancellation request fails.
+    """
 
     def __init__(
         self,
@@ -33,49 +243,25 @@ class AsyncOneshotSession:
         count: int,
         name: str | None = None,
     ) -> None:
-        """Initialization."""
+        super().__init__(count=count, name=name)
         self._http_client = http_client
         self._base_url: str = base_url
         self._service_type: ServiceType = ServiceType.ONESHOT
         self._service_subtype: ServiceSubtype = ServiceSubtype(subtype)
         self._proj_id: UUID = UUID(str(proj_id))
         self._user_id: UUID = UUID(str(user_id))
-        self._name = name
-        self._job_id: UUID | None = None
-        self._count = self.count = count
-
-    @property
-    def count(self) -> int:
-        """Return the count value used for reservation or usage."""
-        return self._count
-
-    @count.setter
-    def count(self, value: int) -> None:
-        """Set the count to be used for usage."""
-        if not isinstance(value, int) or value < 0:
-            errmsg = "count must be an integer >= 0"
-            raise ValueError(errmsg)
-        if self.count is not None and self.count != value:
-            L.info("Overriding previous count value %s with %s", self.count, value)
-        self._count = value
-
-    @property
-    def name(self) -> str | None:
-        """Return the job name."""
-        return self._name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        """Set the job name."""
-        if not isinstance(value, str) or len(value) > MAX_JOB_NAME_LENGTH:
-            errmsg = f"Job name must be a string with max length {MAX_JOB_NAME_LENGTH}"
-            raise ValueError(errmsg)
-        if self.name is not None and self.name != value:
-            L.info("Overriding previous name value '%s' with '%s'", self.name, value)
-        self._name = value
 
     async def make_reservation(self) -> None:
-        """Make a new reservation."""
+        """Reserve budget by calling the accounting service.
+
+        Sends a POST request to the reservation endpoint. On success, sets
+        ``job_id`` to the value returned by the service.
+
+        Raises:
+            RuntimeError: If called more than once.
+            InsufficientFundsError: If the project budget is insufficient (HTTP 402).
+            AccountingReservationError: On request or response errors.
+        """
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
             raise RuntimeError(errmsg)
@@ -112,8 +298,20 @@ class AsyncOneshotSession:
     async def start(self) -> None:
         """Start accounting for the current job. Not used for Oneshot jobs."""
 
-    async def _cancel_reservation(self) -> None:
-        """Cancel the reservation."""
+    async def cancel_reservation(self) -> None:
+        """Cancel the reservation by calling the accounting service.
+
+        Sends a DELETE request to release the reserved budget. Cannot be called
+        after a successful ``finish``.
+
+        Raises:
+            RuntimeError: If called after ``finish`` completed successfully,
+                or if no reservation has been made.
+            AccountingCancellationError: On request or response errors.
+        """
+        if self._finished:
+            errmsg = "Cannot cancel a reservation after a successful finish"
+            raise RuntimeError(errmsg)
         if self._job_id is None:
             errmsg = "Cannot cancel a reservation without a job id"
             raise RuntimeError(errmsg)
@@ -163,54 +361,59 @@ class AsyncOneshotSession:
         _exc_val: BaseException | None = None,
         _exc_tb: TracebackType | None = None,
     ) -> None:
+        """Finalize the session.
+
+        If ``exc_type`` is ``None``, reports usage to the accounting service and
+        marks the session as finished. If an exception type is provided, attempts
+        to cancel the reservation instead (logging a warning on cancellation failure).
+        """
         if exc_type is None:
             await self._send_usage()
+            self._finished = True
         else:
             L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
             try:
-                await self._cancel_reservation()
+                await self.cancel_reservation()
             except AccountingCancellationError as ex:
                 L.warning("Error while cancelling the reservation: %r", ex)
 
-    async def __aenter__(self) -> Self:
-        """Initialize when entering the context manager."""
-        await self.make_reservation()
-        return self
 
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Cleanup when exiting the context manager."""
-        await self.finish(exc_type, exc_val, exc_tb)
+class AsyncNullOneshotSession(AsyncBaseOneshotSession):
+    """No-op oneshot session for use when accounting is disabled.
 
+    Implements the same interface as ``AsyncOneshotSession`` without making
+    any HTTP calls. A unique ``job_id`` is auto-generated on reservation so
+    that downstream code relying on ``job_id`` continues to work.
 
-class AsyncNullOneshotSession:
-    """Null session that can be used to do nothing."""
+    Initializes with ``count=0`` and ``name=None``. Both can be set afterwards
+    if needed.
+    """
 
     def __init__(self) -> None:
-        """Initialization."""
-        self.count = 0
-
-    async def __aenter__(self) -> Self:
-        """Initialize when entering the context manager."""
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Cleanup when exiting the context manager."""
+        super().__init__(count=0)
 
     async def make_reservation(self) -> None:
-        """Make a reservation for the current job."""
+        """Generate a local job id without contacting the accounting service.
+
+        Raises:
+            RuntimeError: If called more than once.
+        """
+        if self._job_id is not None:
+            errmsg = "Cannot make a reservation more than once"
+            raise RuntimeError(errmsg)
+        self._job_id = uuid4()
 
     async def start(self) -> None:
-        """Start accounting for the current job."""
+        """No-op. Start is not used for oneshot jobs."""
 
-    async def finish(self) -> None:
-        """Finalize accounting session for the current job."""
+    async def finish(
+        self,
+        exc_type: type[BaseException] | None = None,  # noqa: ARG002
+        _exc_val: BaseException | None = None,
+        _exc_tb: TracebackType | None = None,
+    ) -> None:
+        """No-op finalization. Marks the session as finished."""
+        self._finished = True
+
+    async def cancel_reservation(self) -> None:
+        """No-op cancellation."""

--- a/src/obp_accounting_sdk/_async/oneshot.py
+++ b/src/obp_accounting_sdk/_async/oneshot.py
@@ -53,7 +53,7 @@ from abc import ABC, abstractmethod
 from http import HTTPStatus
 from types import TracebackType
 from typing import Self
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import httpx
 
@@ -401,7 +401,7 @@ class AsyncNullOneshotSession(AsyncBaseOneshotSession):
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
             raise RuntimeError(errmsg)
-        self._job_id = uuid4()
+        self._job_id = UUID(int=0)
 
     async def start(self) -> None:
         """No-op. Start is not used for oneshot jobs."""

--- a/src/obp_accounting_sdk/_sync/factory.py
+++ b/src/obp_accounting_sdk/_sync/factory.py
@@ -81,6 +81,7 @@ class AccountingSessionFactory:
         if not self._http_client:
             errmsg = "The internal http client is not set"
             raise RuntimeError(errmsg)
+
         data = _prepare_estimate_oneshot_cost_data(
             subtype=subtype,
             count=count,

--- a/src/obp_accounting_sdk/_sync/oneshot.py
+++ b/src/obp_accounting_sdk/_sync/oneshot.py
@@ -53,7 +53,7 @@ from abc import ABC, abstractmethod
 from http import HTTPStatus
 from types import TracebackType
 from typing import Self
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import httpx
 
@@ -401,7 +401,7 @@ class NullOneshotSession(SyncBaseOneshotSession):
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
             raise RuntimeError(errmsg)
-        self._job_id = uuid4()
+        self._job_id = UUID(int=0)
 
     def start(self) -> None:
         """No-op. Start is not used for oneshot jobs."""

--- a/src/obp_accounting_sdk/_sync/oneshot.py
+++ b/src/obp_accounting_sdk/_sync/oneshot.py
@@ -1,10 +1,59 @@
-"""Oneshot session."""
+"""Oneshot accounting sessions for single-use jobs.
+
+This module provides async oneshot session classes for reserving and tracking
+usage of short computational jobs against the accounting service.
+
+Two concrete implementations are available:
+
+- ``AsyncOneshotSession``: Communicates with the accounting HTTP API to reserve
+  budget, report usage, and cancel reservations.
+- ``AsyncNullOneshotSession``: A no-op implementation that satisfies the same
+  interface without making any HTTP calls. Useful for testing, local development,
+  or when accounting is disabled.
+
+Both classes share a common interface defined by ``AsyncBaseOneshotSession`` and
+can be used as async context managers or managed manually.
+
+Usage as a context manager:
+
+    async with AsyncOneshotSession(
+        http_client=client,
+        subtype=ServiceSubtype.ML_LLM,
+        proj_id="...",
+        user_id="...",
+        count=10,
+    ) as session:
+        # perform work
+        session.count = actual_count  # optionally adjust before exit
+
+On context exit, usage is automatically reported on success, or the reservation
+is cancelled if an unhandled exception occurs.
+
+Manual lifecycle management::
+
+    session = AsyncOneshotSession(
+        http_client=client,
+        subtype=ServiceSubtype.ML_LLM,
+        proj_id="...",
+        user_id="...",
+        count=10,
+    )
+    await session.make_reservation()
+    try:
+        # perform work
+        session.count = actual_count  # optionally adjust before finishing
+        await session.finish()
+    except Exception:
+        await session.cancel_reservation()
+        raise
+"""
 
 import logging
+from abc import ABC, abstractmethod
 from http import HTTPStatus
 from types import TracebackType
 from typing import Self
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 
@@ -20,8 +69,169 @@ from obp_accounting_sdk.utils import get_current_timestamp
 L = logging.getLogger(__name__)
 
 
-class OneshotSession:
-    """Oneshot Session."""
+class SyncBaseOneshotSession(ABC):
+    """Abstract base class defining the interface for all oneshot sessions.
+
+    Subclasses must implement ``make_reservation``, ``start``, ``finish``, and
+    ``cancel_reservation``. Common properties (``job_id``, ``count``, ``name``)
+    and context manager behaviour are provided by this base class.
+
+    This class should not be instantiated directly. Use one of the concrete
+    implementations: ``AsyncOneshotSession`` or ``AsyncNullOneshotSession``.
+    """
+
+    def __init__(self, count: int, name: str | None = None) -> None:
+        """Initialize shared session state.
+
+        Args:
+            count: The number of units to reserve. Must be a non-negative integer.
+            name: Optional human-readable name for the job.
+        """
+        self._job_id: UUID | None = None
+        self._finished: bool = False
+        self._name = name
+        self._count = self.count = count
+
+    @property
+    def job_id(self) -> UUID | None:
+        """The unique identifier assigned to this job upon reservation.
+
+        Returns ``None`` before ``make_reservation`` is called. Read-only.
+        """
+        return self._job_id
+
+    @property
+    def count(self) -> int:
+        """The number of units to reserve or report as usage.
+
+        Can be updated after initialization but before ``finish`` is called,
+        allowing the actual usage to differ from the initial reservation.
+        """
+        return self._count
+
+    @count.setter
+    def count(self, value: int) -> None:
+        """Set the count value.
+
+        Raises:
+            ValueError: If set to a non-integer or negative value.
+        """
+        if not isinstance(value, int) or value < 0:  # pyright: ignore[reportUnnecessaryIsInstance]
+            errmsg = "count must be an integer >= 0"
+            raise ValueError(errmsg)
+        if self._count != value:
+            L.info("Overriding previous count value %s with %s", self._count, value)
+        self._count = value
+
+    @property
+    def name(self) -> str | None:
+        """Optional human-readable name for the job.
+
+        Can be set at initialization or updated afterwards. Maximum length is
+        defined by ``MAX_JOB_NAME_LENGTH``.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Set the job name.
+
+        Raises:
+            ValueError: If set to a non-string or a string exceeding the max length.
+        """
+        if not isinstance(value, str) or len(value) > MAX_JOB_NAME_LENGTH:  # pyright: ignore[reportUnnecessaryIsInstance]
+            errmsg = f"Job name must be a string with max length {MAX_JOB_NAME_LENGTH}"
+            raise ValueError(errmsg)
+        if self._name is not None and self._name != value:
+            L.info("Overriding previous name value '%s' with '%s'", self._name, value)
+        self._name = value
+
+    @abstractmethod
+    def make_reservation(self) -> None:
+        """Reserve budget for a oneshot job.
+
+        Must be called exactly once before ``finish`` or ``cancel_reservation``.
+        After a successful call, ``job_id`` is set.
+
+        Raises:
+            RuntimeError: If called more than once.
+        """
+
+    @abstractmethod
+    def start(self) -> None:
+        """Start accounting for the current job. Not used for oneshot jobs."""
+
+    @abstractmethod
+    def finish(
+        self,
+        exc_type: type[BaseException] | None = None,
+        _exc_val: BaseException | None = None,
+        _exc_tb: TracebackType | None = None,
+    ) -> None:
+        """Finalize the session by reporting usage or cancelling on error.
+
+        When called without arguments (or with ``exc_type=None``), reports
+        successful usage. When called with exception info (as done automatically
+        by the context manager on unhandled errors), cancels the reservation.
+
+        After a successful finish, ``cancel_reservation`` can no longer be called.
+
+        Args:
+            exc_type: The exception type if finishing due to an error, or ``None``
+                for a successful finish.
+            _exc_val: The exception instance (used by the context manager protocol).
+            _exc_tb: The traceback (used by the context manager protocol).
+        """
+
+    @abstractmethod
+    def cancel_reservation(self) -> None:
+        """Cancel the current reservation.
+
+        Releases the reserved budget without reporting usage. Cannot be called
+        after a successful ``finish``.
+
+        Raises:
+            RuntimeError: If called after ``finish`` completed successfully.
+        """
+
+    def __enter__(self) -> Self:
+        """Initialize when entering the context manager."""
+        self.make_reservation()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Cleanup when exiting the context manager."""
+        self.finish(exc_type, exc_val, exc_tb)
+
+
+class OneshotSession(SyncBaseOneshotSession):
+    """Oneshot session that communicates with the accounting HTTP API.
+
+    Manages the full lifecycle of a oneshot job: reserving budget, reporting
+    usage on success, and cancelling the reservation on failure. Can be used
+    as an async context manager or managed manually.
+
+    Args:
+        http_client: An ``httpx.AsyncClient`` instance used for HTTP requests.
+        base_url: Root URL of the accounting service. Typically set via
+            environment variable and not customized at runtime.
+        subtype: The service subtype for this job (e.g. ``ServiceSubtype.ML_LLM``).
+        proj_id: The project identifier.
+        user_id: The user identifier.
+        count: The number of units to reserve. Can be adjusted before ``finish``.
+        name: Optional human-readable name for the job.
+
+    Raises:
+        InsufficientFundsError: If the project does not have enough budget.
+        AccountingReservationError: If the reservation request fails.
+        AccountingUsageError: If the usage report fails.
+        AccountingCancellationError: If the cancellation request fails.
+    """
 
     def __init__(
         self,
@@ -33,49 +243,25 @@ class OneshotSession:
         count: int,
         name: str | None = None,
     ) -> None:
-        """Initialization."""
+        super().__init__(count=count, name=name)
         self._http_client = http_client
         self._base_url: str = base_url
         self._service_type: ServiceType = ServiceType.ONESHOT
         self._service_subtype: ServiceSubtype = ServiceSubtype(subtype)
         self._proj_id: UUID = UUID(str(proj_id))
         self._user_id: UUID = UUID(str(user_id))
-        self._name = name
-        self._job_id: UUID | None = None
-        self._count = self.count = count
-
-    @property
-    def count(self) -> int:
-        """Return the count value used for reservation or usage."""
-        return self._count
-
-    @count.setter
-    def count(self, value: int) -> None:
-        """Set the count to be used for usage."""
-        if not isinstance(value, int) or value < 0:
-            errmsg = "count must be an integer >= 0"
-            raise ValueError(errmsg)
-        if self.count is not None and self.count != value:
-            L.info("Overriding previous count value %s with %s", self.count, value)
-        self._count = value
-
-    @property
-    def name(self) -> str | None:
-        """Return the job name."""
-        return self._name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        """Set the job name."""
-        if not isinstance(value, str) or len(value) > MAX_JOB_NAME_LENGTH:
-            errmsg = f"Job name must be a string with max length {MAX_JOB_NAME_LENGTH}"
-            raise ValueError(errmsg)
-        if self.name is not None and self.name != value:
-            L.info("Overriding previous name value '%s' with '%s'", self.name, value)
-        self._name = value
 
     def make_reservation(self) -> None:
-        """Make a new reservation."""
+        """Reserve budget by calling the accounting service.
+
+        Sends a POST request to the reservation endpoint. On success, sets
+        ``job_id`` to the value returned by the service.
+
+        Raises:
+            RuntimeError: If called more than once.
+            InsufficientFundsError: If the project budget is insufficient (HTTP 402).
+            AccountingReservationError: On request or response errors.
+        """
         if self._job_id is not None:
             errmsg = "Cannot make a reservation more than once"
             raise RuntimeError(errmsg)
@@ -112,8 +298,20 @@ class OneshotSession:
     def start(self) -> None:
         """Start accounting for the current job. Not used for Oneshot jobs."""
 
-    def _cancel_reservation(self) -> None:
-        """Cancel the reservation."""
+    def cancel_reservation(self) -> None:
+        """Cancel the reservation by calling the accounting service.
+
+        Sends a DELETE request to release the reserved budget. Cannot be called
+        after a successful ``finish``.
+
+        Raises:
+            RuntimeError: If called after ``finish`` completed successfully,
+                or if no reservation has been made.
+            AccountingCancellationError: On request or response errors.
+        """
+        if self._finished:
+            errmsg = "Cannot cancel a reservation after a successful finish"
+            raise RuntimeError(errmsg)
         if self._job_id is None:
             errmsg = "Cannot cancel a reservation without a job id"
             raise RuntimeError(errmsg)
@@ -163,54 +361,59 @@ class OneshotSession:
         _exc_val: BaseException | None = None,
         _exc_tb: TracebackType | None = None,
     ) -> None:
+        """Finalize the session.
+
+        If ``exc_type`` is ``None``, reports usage to the accounting service and
+        marks the session as finished. If an exception type is provided, attempts
+        to cancel the reservation instead (logging a warning on cancellation failure).
+        """
         if exc_type is None:
             self._send_usage()
+            self._finished = True
         else:
             L.warning(f"Unhandled application error {exc_type.__name__}, cancelling reservation")
             try:
-                self._cancel_reservation()
+                self.cancel_reservation()
             except AccountingCancellationError as ex:
                 L.warning("Error while cancelling the reservation: %r", ex)
 
-    def __enter__(self) -> Self:
-        """Initialize when entering the context manager."""
-        self.make_reservation()
-        return self
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Cleanup when exiting the context manager."""
-        self.finish(exc_type, exc_val, exc_tb)
+class NullOneshotSession(SyncBaseOneshotSession):
+    """No-op oneshot session for use when accounting is disabled.
 
+    Implements the same interface as ``AsyncOneshotSession`` without making
+    any HTTP calls. A unique ``job_id`` is auto-generated on reservation so
+    that downstream code relying on ``job_id`` continues to work.
 
-class NullOneshotSession:
-    """Null session that can be used to do nothing."""
+    Initializes with ``count=0`` and ``name=None``. Both can be set afterwards
+    if needed.
+    """
 
     def __init__(self) -> None:
-        """Initialization."""
-        self.count = 0
-
-    def __enter__(self) -> Self:
-        """Initialize when entering the context manager."""
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Cleanup when exiting the context manager."""
+        super().__init__(count=0)
 
     def make_reservation(self) -> None:
-        """Make a reservation for the current job."""
+        """Generate a local job id without contacting the accounting service.
+
+        Raises:
+            RuntimeError: If called more than once.
+        """
+        if self._job_id is not None:
+            errmsg = "Cannot make a reservation more than once"
+            raise RuntimeError(errmsg)
+        self._job_id = uuid4()
 
     def start(self) -> None:
-        """Start accounting for the current job."""
+        """No-op. Start is not used for oneshot jobs."""
 
-    def finish(self) -> None:
-        """Finalize accounting session for the current job."""
+    def finish(
+        self,
+        exc_type: type[BaseException] | None = None,  # noqa: ARG002
+        _exc_val: BaseException | None = None,
+        _exc_tb: TracebackType | None = None,
+    ) -> None:
+        """No-op finalization. Marks the session as finished."""
+        self._finished = True
+
+    def cancel_reservation(self) -> None:
+        """No-op cancellation."""

--- a/tests/_async/test_oneshot.py
+++ b/tests/_async/test_oneshot.py
@@ -1,4 +1,5 @@
 import re
+from uuid import UUID
 
 import httpx
 import pytest
@@ -241,7 +242,7 @@ async def test_oneshot_session_improperly_used(httpx_mock):
         ):
             await session._send_usage()
         with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
-            await session._cancel_reservation()
+            await session.cancel_reservation()
         await session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
             await session.make_reservation()
@@ -349,6 +350,79 @@ async def test_oneshot_session_with_application_error_and_cancellation_timeout(h
     )
 
 
+async def test_oneshot_session_cancel_after_finish(httpx_mock):
+    httpx_mock.add_response(
+        json={"message": "", "data": {"job_id": JOB_ID}},
+        method="POST",
+        url=f"{BASE_URL}/reservation/oneshot",
+    )
+    httpx_mock.add_response(
+        json={"message": "", "data": None},
+        method="POST",
+        url=f"{BASE_URL}/usage/oneshot",
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        session = test_module.AsyncOneshotSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            count=10,
+        )
+        await session.make_reservation()
+        await session.finish()
+        with pytest.raises(
+            RuntimeError, match="Cannot cancel a reservation after a successful finish"
+        ):
+            await session.cancel_reservation()
+
+
+async def test_oneshot_session_job_id(httpx_mock):
+    httpx_mock.add_response(
+        json={"message": "", "data": {"job_id": JOB_ID}},
+        method="POST",
+        url=f"{BASE_URL}/reservation/oneshot",
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        session = test_module.AsyncOneshotSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            count=10,
+        )
+        assert session.job_id is None
+        await session.make_reservation()
+        assert session.job_id == UUID(JOB_ID)
+
+
 async def test_oneshot_session_null_as_context_manager():
     async with test_module.AsyncNullOneshotSession() as session:
         assert session.count == 0
+        assert session.job_id is not None
+        assert isinstance(session.job_id, UUID)
+
+
+async def test_null_session_job_id():
+    session = test_module.AsyncNullOneshotSession()
+    assert session.job_id is None
+    await session.make_reservation()
+    assert session.job_id is not None
+    assert isinstance(session.job_id, UUID)
+
+
+async def test_null_session_cannot_reserve_twice():
+    session = test_module.AsyncNullOneshotSession()
+    await session.make_reservation()
+    with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
+        await session.make_reservation()
+
+
+async def test_null_session_cancel_reservation():
+    session = test_module.AsyncNullOneshotSession()
+    await session.make_reservation()
+    await session.cancel_reservation()  # should be a no-op

--- a/tests/_async/test_oneshot.py
+++ b/tests/_async/test_oneshot.py
@@ -403,16 +403,14 @@ async def test_oneshot_session_job_id(httpx_mock):
 async def test_oneshot_session_null_as_context_manager():
     async with test_module.AsyncNullOneshotSession() as session:
         assert session.count == 0
-        assert session.job_id is not None
-        assert isinstance(session.job_id, UUID)
+        assert session.job_id == UUID(int=0)
 
 
 async def test_null_session_job_id():
     session = test_module.AsyncNullOneshotSession()
     assert session.job_id is None
     await session.make_reservation()
-    assert session.job_id is not None
-    assert isinstance(session.job_id, UUID)
+    assert session.job_id == UUID(int=0)
 
 
 async def test_null_session_cannot_reserve_twice():

--- a/tests/_sync/test_oneshot.py
+++ b/tests/_sync/test_oneshot.py
@@ -1,4 +1,5 @@
 import re
+from uuid import UUID
 
 import httpx
 import pytest
@@ -241,7 +242,7 @@ def test_oneshot_session_improperly_used(httpx_mock):
         ):
             session._send_usage()
         with pytest.raises(RuntimeError, match="Cannot cancel a reservation without a job id"):
-            session._cancel_reservation()
+            session.cancel_reservation()
         session.make_reservation()
         with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
             session.make_reservation()
@@ -349,6 +350,79 @@ def test_oneshot_session_with_application_error_and_cancellation_timeout(httpx_m
     )
 
 
+def test_oneshot_session_cancel_after_finish(httpx_mock):
+    httpx_mock.add_response(
+        json={"message": "", "data": {"job_id": JOB_ID}},
+        method="POST",
+        url=f"{BASE_URL}/reservation/oneshot",
+    )
+    httpx_mock.add_response(
+        json={"message": "", "data": None},
+        method="POST",
+        url=f"{BASE_URL}/usage/oneshot",
+    )
+
+    with httpx.Client() as http_client:
+        session = test_module.OneshotSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            count=10,
+        )
+        session.make_reservation()
+        session.finish()
+        with pytest.raises(
+            RuntimeError, match="Cannot cancel a reservation after a successful finish"
+        ):
+            session.cancel_reservation()
+
+
+def test_oneshot_session_job_id(httpx_mock):
+    httpx_mock.add_response(
+        json={"message": "", "data": {"job_id": JOB_ID}},
+        method="POST",
+        url=f"{BASE_URL}/reservation/oneshot",
+    )
+
+    with httpx.Client() as http_client:
+        session = test_module.OneshotSession(
+            http_client=http_client,
+            base_url=BASE_URL,
+            subtype=ServiceSubtype.ML_LLM,
+            proj_id=PROJ_ID,
+            user_id=USER_ID,
+            count=10,
+        )
+        assert session.job_id is None
+        session.make_reservation()
+        assert session.job_id == UUID(JOB_ID)
+
+
 def test_oneshot_session_null_as_context_manager():
     with test_module.NullOneshotSession() as session:
         assert session.count == 0
+        assert session.job_id is not None
+        assert isinstance(session.job_id, UUID)
+
+
+def test_null_session_job_id():
+    session = test_module.NullOneshotSession()
+    assert session.job_id is None
+    session.make_reservation()
+    assert session.job_id is not None
+    assert isinstance(session.job_id, UUID)
+
+
+def test_null_session_cannot_reserve_twice():
+    session = test_module.NullOneshotSession()
+    session.make_reservation()
+    with pytest.raises(RuntimeError, match="Cannot make a reservation more than once"):
+        session.make_reservation()
+
+
+def test_null_session_cancel_reservation():
+    session = test_module.NullOneshotSession()
+    session.make_reservation()
+    session.cancel_reservation()  # should be a no-op

--- a/tests/_sync/test_oneshot.py
+++ b/tests/_sync/test_oneshot.py
@@ -403,16 +403,14 @@ def test_oneshot_session_job_id(httpx_mock):
 def test_oneshot_session_null_as_context_manager():
     with test_module.NullOneshotSession() as session:
         assert session.count == 0
-        assert session.job_id is not None
-        assert isinstance(session.job_id, UUID)
+        assert session.job_id == UUID(int=0)
 
 
 def test_null_session_job_id():
     session = test_module.NullOneshotSession()
     assert session.job_id is None
     session.make_reservation()
-    assert session.job_id is not None
-    assert isinstance(session.job_id, UUID)
+    assert session.job_id == UUID(int=0)
 
 
 def test_null_session_cannot_reserve_twice():


### PR DESCRIPTION
## Refactor oneshot sessions with ABC base class and null implementation

  ### Changes

  - **Introduced `BaseOneshotSession` ABC** (async + sync) extracting shared state (`job_id`, `count`, `name`) and context manager logic from the concrete session classes
  - **Improved `NullOneshotSession`** — now extends the base class, generates a local `job_id` on reservation, and implements all lifecycle methods (`finish`, `cancel_reservation`) instead of being a bare stub
  - **Made `_cancel_reservation` public** — renamed to `cancel_reservation()` for manual lifecycle management
  - **Added `_finished` guard** — prevents `cancel_reservation` after a successful `finish`
  - **Exposed `job_id` property** (read-only) on the base class
  - **Added comprehensive docstrings** to modules, classes, and methods
  - **Updated tests** — new test coverage for the null session and lifecycle edge cases

  ### Files changed

  | File | What |
  |------|------|
  | `_async/oneshot.py` | ABC base + refactored async sessions |
  | `_sync/oneshot.py` | ABC base + refactored sync sessions |
  | `_sync/factory.py` | Whitespace fix |
  | `tests/_async/test_oneshot.py` | New null session + lifecycle tests |
  | `tests/_sync/test_oneshot.py` | Same for sync variant |